### PR TITLE
Handle JobRunExecutorActor.Failed as well as Finished and Aborted

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -299,22 +299,20 @@ class JobRunExecutorActor(
   }
 
   def aborting: Receive = around {
-    receiveKill orElse {
-      // We can't handle a successful deletion and a failure differently
-      case JobRunDeleted(_, persisted, _) =>
-        log.info(s"Execution of JobRun ${jobRun.id} was aborted")
-        val result = JobResult(jobRun)
-        context.parent ! Aborted(result)
-        promise.failure(JobRunFailed(result))
-        context.become(terminal)
+    // We can't handle a successful deletion and a failure differently
+    case JobRunDeleted(_, persisted, _) =>
+      log.info(s"Execution of JobRun ${jobRun.id} was aborted")
+      val result = JobResult(jobRun)
+      context.parent ! Aborted(result)
+      promise.failure(JobRunFailed(result))
+      context.become(terminal)
 
-      case PersistFailed(_, id, ex, _) =>
-        log.info(s"Execution of JobRun ${jobRun.id} was aborted and deleting failed")
-        val result = JobResult(jobRun)
-        context.parent ! Aborted(result)
-        promise.failure(JobRunFailed(result))
-        context.become(terminal)
-    }
+    case PersistFailed(_, id, ex, _) =>
+      log.info(s"Execution of JobRun ${jobRun.id} was aborted and deleting failed")
+      val result = JobResult(jobRun)
+      context.parent ! Aborted(result)
+      promise.failure(JobRunFailed(result))
+      context.become(terminal)
   }
 
   def terminal: Receive = around {


### PR DESCRIPTION
There are 3 distinct messages a JobRunExecutorActor sends to his parent after a JobRun terminated: Finished, Aborted or Failed. The latter one wasn't handled until now. Although the JobRunServiceActor handles Aborted and failed equally, I've kept the verbose messaging from the executor.
