### PR TITLE
Removed impossible fallback to scallopConf

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -401,6 +401,7 @@ metronome {
 
     # (Optional) The url pointing to the leading mesos master UI. If not provided, it will be set to
     # "http://${master.getHostname}:${master.getPort}/" upon registration with mesos.
+    # Note: When this option is set, the given url should always load balance to current Mesos master
     leader.ui.url = ${?METRONOME_MESOS_LEADER_UI_URL}
 
     # (Optional. Default: "localhost:5050") The url pointing to the mesos master.

--- a/src/main/scala/dcos/metronome/MetronomeConfig.scala
+++ b/src/main/scala/dcos/metronome/MetronomeConfig.scala
@@ -15,7 +15,7 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
 
   lazy val frameworkName: String = configuration.getString("metronome.framework.name").getOrElse("metronome")
   lazy val mesosMaster: String = configuration.getString("metronome.mesos.master.url").getOrElse("localhost:5050")
-  override lazy val mesosLeaderUiUrl: Option[String] = configuration.getString("metronome.mesos.leader.ui.url").orElse(scallopConf.mesosLeaderUiUrl.get)
+  override lazy val mesosLeaderUiUrl: Option[String] = configuration.getString("metronome.mesos.leader.ui.url")
   lazy val mesosRole: Option[String] = configuration.getString("metronome.mesos.role")
   lazy val mesosUser: Option[String] = configuration.getString("metronome.mesos.user").orElse(new SystemProperties().get("user.name"))
   lazy val mesosExecutorDefault: String = configuration.getString("metronome.mesos.executor.default").getOrElse("//cmd")


### PR DESCRIPTION
We can't fallback to a config value from the scallopConf as the scallopConf is created using the play config …
