### PR TITLE
Add tests for cron format and update to latest cron-utils

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -1,0 +1,63 @@
+package dcos.metronome.api.v1
+
+import dcos.metronome.api.v1.models._
+import dcos.metronome.model.CronSpec
+import dcos.metronome.utils.test.Mockito
+import org.scalatest.{ FunSuite, Matchers }
+import play.api.libs.json.Json
+
+class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
+
+  test("Every minute") {
+    val cronString = "* * * * *"
+    CronSpec.isValid(cronString) shouldBe true
+
+    val spec = CronSpec(cronString)
+    spec.toString shouldEqual cronString
+
+    Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+
+  test("Every minute alternate") {
+    val redundantCronString = "*/1 * * * *"
+    val correctCronString = "* * * * *"
+    CronSpec.isValid(redundantCronString) shouldBe true
+    CronSpec.isValid(correctCronString) shouldBe true
+
+    val spec = CronSpec(redundantCronString)
+    // the */1 is actually redundant and will be 'fixed' by the parser
+    spec.toString shouldEqual correctCronString
+
+    Json.toJson(spec).as[CronSpec].toString shouldEqual correctCronString
+  }
+
+  test("Every 2 minutes") {
+    val cronString = "*/2 * * * *"
+    CronSpec.isValid(cronString) shouldBe true
+
+    val spec = CronSpec(cronString)
+    spec.toString shouldEqual cronString
+
+    Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+
+  test("Every 5 minutes") {
+    val cronString = "*/5 * * * *"
+    CronSpec.isValid(cronString) shouldBe true
+
+    val spec = CronSpec(cronString)
+    spec.toString shouldEqual cronString
+
+    Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+
+  test("Every Friday") {
+    val cronString = "0 0 * * 5"
+    CronSpec.isValid(cronString) shouldBe true
+
+    val spec = CronSpec(cronString)
+    spec.toString shouldEqual cronString
+
+    Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -131,7 +131,7 @@ object Build extends sbt.Build {
       val MacWire = "2.2.2"
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
-      val CronUtils = "3.1.6"
+      val CronUtils = "4.1.0"
       val WixAccord = "0.5"
       val Akka = "2.3.15"
       val Mockito = "2.0.54-beta"


### PR DESCRIPTION
As documented in [DCOS-8174](https://mesosphere.atlassian.net/browse/DCOS-8174), redundant cron expressions like `*/1 * * * *` were not correctly handled and the leading `*/1` was dropped resulting in `* * * *` and no JobRuns being scheduled.

Updating the CronUtils fixed this and will correctly convert to `* * * * *`.
