### PR TITLE
Fixed ArtifactFormat

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -35,7 +35,7 @@ package object models {
   )
 
   implicit lazy val ArtifactFormat: Format[Artifact] = (
-    (__ \ "url").format[String] ~
+    (__ \ "uri").format[String] ~
     (__ \ "extract").formatNullable[Boolean].withDefault(true) ~
     (__ \ "executable").formatNullable[Boolean].withDefault(false) ~
     (__ \ "cache").formatNullable[Boolean].withDefault(false)


### PR DESCRIPTION
* the artifact format now correctly parses `uri` as a required parameter, as stated in the schema