### PR TITLE
Fixes DCOS-8897 by adding the historySummary option.

### DIFF
--- a/api/src/main/resources/public/api/v1/jobs.raml
+++ b/api/src/main/resources/public/api/v1/jobs.raml
@@ -15,7 +15,9 @@ get:
 
         - <code>history</code> embed history information, attached to this job<br/>
 
-      enum: [ activeRuns, schedules, history ]
+        - <code>historySummary</code> embed history summary information, attached to this job<br/>
+
+      enum: [ activeRuns, schedules, history, historySummary ]
       repeat: true
       example: activeRuns
   responses:
@@ -78,9 +80,9 @@ post:
 
           - <code>schedules</code> embed all schedules assigned to this job<br/>
 
-          - <code>history</code> embed history information associated with this job<br/>
+          - <code>historySummary</code> embed history summary information, attached to this job<br/>
 
-        enum: [ activeRuns, schedules, history ]
+        enum: [ activeRuns, schedules, history, historySummary ]
         repeat: true
         example: activeRuns
     responses:

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -210,6 +210,14 @@ package object models {
       "failedFinishedRuns" -> o.failedRuns
     )
   }
+  implicit lazy val JobHistorySummaryWrites: Writes[JobHistorySummary] = new Writes[JobHistorySummary] {
+    override def writes(o: JobHistorySummary): JsValue = Json.obj(
+      "successCount" -> o.successCount,
+      "failureCount" -> o.failureCount,
+      "lastSuccessAt" -> o.lastSuccessAt,
+      "lastFailureAt" -> o.lastFailureAt
+    )
+  }
 
   implicit lazy val StartedJobRunWrites: Writes[StartedJobRun] = new Writes[StartedJobRun] {
     override def writes(o: StartedJobRun): JsValue = JobRunWrites.writes(o.jobRun)

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
@@ -7,13 +7,14 @@ import dcos.metronome.model._
   * This class represents a JobSpec with optional enriched data.
   */
 case class JobInfo(
-  id:          JobId,
-  description: Option[String],
-  labels:      Map[String, String],
-  run:         JobRunSpec,
-  schedules:   Option[Seq[ScheduleSpec]],
-  activeRuns:  Option[Iterable[StartedJobRun]],
-  history:     Option[JobHistory]
+  id:             JobId,
+  description:    Option[String],
+  labels:         Map[String, String],
+  run:            JobRunSpec,
+  schedules:      Option[Seq[ScheduleSpec]],
+  activeRuns:     Option[Iterable[StartedJobRun]],
+  history:        Option[JobHistory],
+  historySummary: Option[JobHistorySummary]
 )
 
 object JobInfo {
@@ -22,20 +23,23 @@ object JobInfo {
     val names: Map[String, Embed] = Map(
       "activeRuns" -> ActiveRuns,
       "schedules" -> Schedules,
-      "history" -> History
+      "history" -> History,
+      "historySummary" -> HistorySummary
     )
     case object Schedules extends Embed
     case object ActiveRuns extends Embed
     case object History extends Embed
+    case object HistorySummary extends Embed
   }
 
   def apply(
     spec:      JobSpec,
     schedules: Option[Seq[ScheduleSpec]],
     runs:      Option[Iterable[StartedJobRun]],
-    status:    Option[JobHistory]
+    history:   Option[JobHistory],
+    summary:   Option[JobHistorySummary]
   ): JobInfo = {
-    JobInfo(spec.id, spec.description, spec.labels, spec.run, schedules, runs, status)
+    JobInfo(spec.id, spec.description, spec.labels, spec.run, schedules, runs, history, summary)
   }
 }
 

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImpl.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImpl.scala
@@ -5,7 +5,7 @@ import dcos.metronome.jobinfo.JobInfo.Embed
 import dcos.metronome.jobinfo.{ JobInfo, JobSpecSelector, JobInfoService }
 import dcos.metronome.jobrun.{ StartedJobRun, JobRunService }
 import dcos.metronome.jobspec.JobSpecService
-import dcos.metronome.model.{ JobId, JobSpec, JobHistory }
+import dcos.metronome.model.{ JobHistorySummary, JobId, JobSpec, JobHistory }
 
 import scala.async.Async.{ async, await }
 import scala.concurrent.{ ExecutionContext, Future }
@@ -15,9 +15,11 @@ class JobInfoServiceImpl(jobSpecService: JobSpecService, jobRunService: JobRunSe
   override def selectJob(jobSpecId: JobId, selector: JobSpecSelector, embed: Set[Embed])(implicit ec: ExecutionContext): Future[Option[JobInfo]] = {
     async {
       val runOption = if (embed(Embed.ActiveRuns)) Some(await(jobRunService.activeRuns(jobSpecId))) else None
-      val historyOption = if (embed(Embed.History)) await(jobHistoryService.statusFor(jobSpecId)).orElse(Some(JobHistory.empty(jobSpecId))) else None
+      val historyData = if (embed(Embed.History) || embed(Embed.HistorySummary)) await(jobHistoryService.statusFor(jobSpecId)).orElse(Some(JobHistory.empty(jobSpecId))) else None
+      val historyOption = if (embed(Embed.History)) historyData else None
+      val summaryOption = if (embed(Embed.HistorySummary)) historyData.map(JobHistorySummary.apply) else None
       await(jobSpecService.getJobSpec(jobSpecId)).filter(selector.matches).map { jobSpec =>
-        JobInfo(jobSpec, schedulesOption(jobSpec, embed), runOption, historyOption)
+        JobInfo(jobSpec, schedulesOption(jobSpec, embed), runOption, historyOption, summaryOption)
       }
     }
   }
@@ -31,15 +33,19 @@ class JobInfoServiceImpl(jobSpecService: JobSpecService, jobRunService: JobRunSe
           await(jobRunService.listRuns(run => allIds(run.jobSpec.id))).groupBy(_.jobRun.jobSpec.id)
         else
           Map.empty[JobId, Seq[StartedJobRun]]
-      val histories =
-        if (embed(Embed.History))
+      val availableHistories =
+        if (embed(Embed.History) || embed(Embed.HistorySummary))
           await(jobHistoryService.list(history => allIds(history.jobSpecId))).map(history => history.jobSpecId -> history).toMap
         else
           Map.empty[JobId, JobHistory]
+      val histories = if (embed(Embed.History)) availableHistories else Map.empty[JobId, JobHistory]
+      val summaries = if (embed(Embed.HistorySummary)) availableHistories.map{ case (i, h) => i -> JobHistorySummary(h) } else Map.empty[JobId, JobHistorySummary]
       def history(id: JobId): Option[JobHistory] =
         if (embed(Embed.History)) histories.get(id).orElse(Some(JobHistory.empty(id))) else None
+      def summary(id: JobId): Option[JobHistorySummary] =
+        if (embed(Embed.HistorySummary)) summaries.get(id).orElse(Some(JobHistorySummary.empty(id))) else None
       specs.map { spec =>
-        JobInfo(spec, schedulesOption(spec, embed), runs.get(spec.id), history(spec.id))
+        JobInfo(spec, schedulesOption(spec, embed), runs.get(spec.id), history(spec.id), summary(spec.id))
       }
     }
   }

--- a/jobs/src/main/scala/dcos/metronome/model/JobHistory.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobHistory.scala
@@ -2,6 +2,20 @@ package dcos.metronome.model
 
 import org.joda.time.{ DateTimeZone, DateTime }
 
+case class JobHistorySummary(
+  jobSpecId:     JobId,
+  successCount:  Long,
+  failureCount:  Long,
+  lastSuccessAt: Option[DateTime],
+  lastFailureAt: Option[DateTime]
+)
+object JobHistorySummary {
+  def apply(h: JobHistory): JobHistorySummary = {
+    JobHistorySummary(h.jobSpecId, h.successCount, h.failureCount, h.lastSuccessAt, h.lastFailureAt)
+  }
+  def empty(id: JobId): JobHistorySummary = JobHistorySummary(id, 0, 0, None, None)
+}
+
 case class JobHistory(
   jobSpecId:      JobId,
   successCount:   Long,

--- a/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
@@ -106,6 +106,20 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
     result.map(_.history.get).toSet should be(Set(f.history1, f.history2))
   }
 
+  test("Status embed option will render embedded historyShort info") {
+    Given("A repo with 2 specs and 2 runs")
+    val f = new Fixture
+
+    When("The job info is fetched")
+    val result = f.jobInfoService.selectJobs(JobSpecSelector.all, Set(Embed.HistorySummary)).futureValue
+
+    Then("The extended info is rendered for active runs")
+    result should have size 2
+    result.foreach(_.schedules should be(empty))
+    result.foreach(_.activeRuns should be(empty))
+    result.map(_.historySummary.get).toSet should be(Set(f.historySummary1, f.historySummary2))
+  }
+
   class Fixture {
     val clock = new FixedClock(DateTime.now)
     val CronSpec(cron) = "* * * * *"
@@ -117,6 +131,8 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     val history1 = JobHistory(spec1.id, 23, 23, Some(clock.now()), Some(clock.now()), Seq.empty, Seq.empty)
     val history2 = JobHistory(spec2.id, 23, 23, Some(clock.now()), Some(clock.now()), Seq.empty, Seq.empty)
+    val historySummary1 = JobHistorySummary(history1)
+    val historySummary2 = JobHistorySummary(history2)
 
     val specService = JobSpecServiceFixture.simpleJobSpecService()
     val runService = JobRunServiceFixture.simpleJobRunService()


### PR DESCRIPTION
Added an additional embed option: historySummary.
This will embed only a subset of the history:
```json
    {
        "history": {
            "failedFinishedRuns": [], 
            "failureCount": 0, 
            "lastFailureAt": null, 
            "lastSuccessAt": null, 
            "successCount": 0, 
            "successfulFinishedRuns": []
        }, 
        "historySummary": {
            "failureCount": 0, 
            "lastFailureAt": null, 
            "lastSuccessAt": null, 
            "successCount": 0
        }
}    
```
