### PR TITLE
API Examples update: test.com -> example.com

### DIFF
--- a/api/src/main/resources/public/api/v1/examples/job.json
+++ b/api/src/main/resources/public/api/v1/examples/job.json
@@ -8,7 +8,7 @@
   "run": {
     "artifacts": [
       {
-        "uri": "http://foo.test.com/application.zip",
+        "uri": "http://foo.example.com/application.zip",
         "extract": true,
         "executable": true,
         "cache": false


### PR DESCRIPTION
The domain test.com is actually owned by a company. In accordance with https://tools.ietf.org/html/rfc2606#section-3 we should be using example.com instead as it's reserved for this purpose.