### PR TITLE
Fix api path. action => actions

### DIFF
--- a/api/src/main/resources/public/api/v1/jobs.raml
+++ b/api/src/main/resources/public/api/v1/jobs.raml
@@ -321,7 +321,7 @@ post:
                   { "message": "JobRun 'not_existent' does not exist" }
 
 
-      /action/stop:
+      /actions/stop:
 
         ###
         # Stop a specific job run


### PR DESCRIPTION
I can't do it via '/action/stop'.

(metronome v0.2.0)