### PR TITLE
Fix DCOS-14866 by escaping html tags in the error messages.

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
+++ b/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
@@ -5,22 +5,32 @@ import play.api.http.HttpErrorHandler
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.mvc.{ RequestHeader, Result, Results }
+import play.twirl.api.HtmlFormat
 
 import scala.concurrent.Future
 
 class ErrorHandler extends HttpErrorHandler {
 
-  val log = LoggerFactory.getLogger(getClass)
+  private[this] val log = LoggerFactory.getLogger(getClass)
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     log.debug(s"Client Error on path ${request.path}. Message: $message Status: $statusCode")
-    val json = Json.obj("message" -> message, "requestPath" -> request.path)
+    val json = Json.obj("message" -> escape(message), "requestPath" -> escape(request.path))
     Future.successful(Results.Status(statusCode)(json))
   }
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] = {
     log.error(s"Error serving ${request.path}", exception)
-    val json = Json.obj("requestPath" -> request.path)
+    val json = Json.obj("requestPath" -> escape(request.path))
     Future.successful(Results.Status(INTERNAL_SERVER_ERROR)(json))
   }
+
+  /**
+    * Possible cross site scripting vulnerability: the message could contain html tags, interpreted by a browser.
+    * Example:
+    *      Send: GET /"><script>alert(document.domain)</script>
+    *      Receive: {"message":"Illegal character in path at index 1: /\"><script>alert(document.domain)</script>","requestPath":"/\"><script>alert(document.domain)</script>"}
+    * To prevent possible interpretation of the message: all strings get HTML escaped
+    */
+  private def escape(msg: String): String = HtmlFormat.escape(msg).body
 }


### PR DESCRIPTION
This patch will escape html tags in the error message send in the json response.

Test: 
Start metronome and send 
```
$> http ":9000/dd<script>alert(document.domain)</script>"
```

This will result in a response:
```
HTTP/1.1 404 Not Found
Content-Length: 81
Content-Type: application/json
Date: Thu, 30 Mar 2017 09:55:01 GMT

{
    "message": "",
    "requestPath": "/dd%3Cscript%3Ealert(document.domain)%3C/script%3E"
}
```