### PR TITLE
bin/extra.sh: dynamically use security properties file

### DIFF
--- a/bin/extra.sh
+++ b/bin/extra.sh
@@ -1,9 +1,13 @@
-
 # The content of this file will be added to the metronome start script
 
 if [ -n "${TLS_TRUSTSTORE-}" ]; then
     echo "add trust store: -Djavax.net.ssl.trustStore=$TLS_TRUSTSTORE"
     addJava "-Djavax.net.ssl.trustStore=$TLS_TRUSTSTORE"
+fi
+
+if [ -n "${JVM_SECURITY_PROPERTIES_FILE_PATH-}" ]; then
+    echo "add -Djava.security.properties=${JVM_SECURITY_PROPERTIES_FILE_PATH}"
+    addJava "-Djava.security.properties=${JVM_SECURITY_PROPERTIES_FILE_PATH}"
 fi
 
 # Define default thread pool size


### PR DESCRIPTION
If the environment variable `JVM_SECURITY_PROPERTIES_FILE_PATH` is defined this patch makes sure that the following command line parameter is added to the JVM:

```
-Djava.security.properties=${JVM_SECURITY_PROPERTIES_FILE_PATH}
```

That introduces a convenient configuration interface for a whole plethora of security-related JVM configuration parameters. Excerpt from the header of the default `java.security` file:
```
# This is the "master security properties file".
#
# An alternate java.security properties file may be specified
# from the command line via the system property
#
#    -Djava.security.properties=<URL>
#
# This properties file appends to the master security properties file.
# If both properties files specify values for the same key, the value
# from the command-line properties file is selected, as it is the last
# one loaded.
...
```
