### PR TITLE
Upgrade cron-utils to 4.1.1

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecExecutionTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecExecutionTest.scala
@@ -1,0 +1,26 @@
+package dcos.metronome.api.v1
+
+import dcos.metronome.model.CronSpec
+import org.joda.time.DateTime
+import org.scalatest.{ FunSuite, Matchers }
+
+class CronSpecExecutionTest extends FunSuite with Matchers {
+
+  test("A cron job should execute next Monday when day of week is 1") {
+    val date = (year: Int, month: Int, day: Int) => new DateTime(year, month, day, 0, 0)
+
+    // With cronutils 4.1.0, the execution date is sometimes wrong if the
+    // intended date falls on the first or last day of the month
+    val expectations = Map(
+      date(2017, 4, 25) -> date(2017, 5, 1),
+      date(2017, 7, 28) -> date(2017, 7, 31),
+      date(2017, 12, 27) -> date(2018, 1, 1),
+      date(2018, 4, 29) -> date(2018, 4, 30),
+      date(2018, 9, 30) -> date(2018, 10, 1),
+      date(2018, 12, 26) -> date(2018, 12, 31)
+    )
+    for ((fromDate, executionDate) <- expectations) {
+      CronSpec.apply("* * * * 1").nextExecution(fromDate) shouldEqual executionDate
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -131,7 +131,7 @@ object Build extends sbt.Build {
       val MacWire = "2.2.2"
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
-      val CronUtils = "4.1.0"
+      val CronUtils = "4.1.1"
       val WixAccord = "0.5"
       val Akka = "2.3.15"
       val Mockito = "2.0.54-beta"


### PR DESCRIPTION
There is a bug in cron-utils 4.1.0 which sometimes causes cron jobs that are set to run on a specific day of the week to have the wrong execution time if the intended execution day happens to fall on either the first or last day of the month. I have included a test which fails with cron-utils 4.1.0, but passes with 4.1.1.