### PR TITLE
moving from cron-utils to cron4j

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -18,19 +18,6 @@ class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
     Json.toJson(spec).as[CronSpec] shouldEqual spec
   }
 
-  test("Every minute alternate") {
-    val redundantCronString = "*/1 * * * *"
-    val correctCronString = "* * * * *"
-    CronSpec.isValid(redundantCronString) shouldBe true
-    CronSpec.isValid(correctCronString) shouldBe true
-
-    val spec = CronSpec(redundantCronString)
-    // the */1 is actually redundant and will be 'fixed' by the parser
-    spec.toString shouldEqual correctCronString
-
-    Json.toJson(spec).as[CronSpec].toString shouldEqual correctCronString
-  }
-
   test("Every 2 minutes") {
     val cronString = "*/2 * * * *"
     CronSpec.isValid(cronString) shouldBe true

--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -1,8 +1,13 @@
 package dcos.metronome.api.v1
 
+import java.time.{ LocalDateTime, Month, ZoneId }
+import java.util.Date
+
 import dcos.metronome.api.v1.models._
 import dcos.metronome.model.CronSpec
 import dcos.metronome.utils.test.Mockito
+import it.sauronsoftware.cron4j.Predictor
+import org.joda.time.DateTime
 import org.scalatest.{ FunSuite, Matchers }
 import play.api.libs.json.Json
 
@@ -46,5 +51,82 @@ class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
     spec.toString shouldEqual cronString
 
     Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+
+  test("First Monday Of The Month") {
+    val cronString = "0 9 1-7 * 1"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 11, 6, 9, 0)
+  }
+
+  test("Each weekday the first week Of The Month") {
+    val cronString = "0 9 1-7 * 1-5"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 3, 9, 0)
+  }
+
+  test("Each weekend day the first week Of The Month") {
+    val cronString = "0 9 1-7 * 6-7"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 7, 9, 0)
+  }
+
+  test("Each weekday the second week Of The Month") {
+    val cronString = "0 9 8-14 * 1-5"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 9, 9, 0)
+  }
+
+  test("Each weekend day the fourth week Of The Month") {
+    val cronString = "0 9 22-28 * 6-7"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 22, 9, 0)
+  }
+
+  test("Each day on a wednesday") {
+    val cronString = "* * * * 3"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 4, 0, 0)
+  }
+
+  test("Each day slash of 1 on a wednesday") {
+    val cronString = "* * */1 * 3"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 4, 0, 0)
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
@@ -1,55 +1,37 @@
 package dcos.metronome.model
 
-import com.cronutils.model.definition.{ CronDefinition, CronDefinitionBuilder }
-import com.cronutils.model.time.ExecutionTime
-import com.cronutils.model.Cron
-import com.cronutils.parser.CronParser
+import it.sauronsoftware.cron4j.Predictor
 import org.joda.time.DateTime
 
 import scala.util.control.NonFatal
 
-class CronSpec(val cron: Cron) {
+class CronSpec(val cron: String) {
 
-  private[this] lazy val executionTime: ExecutionTime = ExecutionTime.forCron(cron)
+  new Predictor(cron)
 
-  def nextExecution(from: DateTime): DateTime = executionTime.nextExecution(from)
-
-  def lastExecution(from: DateTime): DateTime = executionTime.lastExecution(from)
+  def nextExecution(from: DateTime): DateTime = new DateTime(new Predictor(cron, from.getMillis).nextMatchingDate());
 
   override def hashCode(): Int = cron.hashCode()
 
   override def equals(obj: scala.Any): Boolean = obj match {
-    case other: CronSpec => other.cron.asString() == cron.asString()
+    case other: CronSpec => other.cron == cron
     case _               => false
   }
 
-  override def toString: String = cron.asString()
+  override def toString: String = cron
 }
 
 object CronSpec {
-  val cronDefinition: CronDefinition =
-    CronDefinitionBuilder.defineCron()
-      .withMinutes().and()
-      .withHours().and()
-      .withDayOfMonth()
-      .supportsHash().supportsL().supportsW().and()
-      .withMonth().and()
-      .withDayOfWeek()
-      .withIntMapping(7, 0) //we support non-standard non-zero-based numbers!
-      .supportsHash().supportsL().supportsW().and()
-      .withYear().and()
-      .lastFieldOptional()
-      .instance()
 
   def isValid(cronString: String): Boolean = unapply(cronString).isDefined
 
   def apply(cronString: String): CronSpec = {
-    new CronSpec(new CronParser(cronDefinition).parse(cronString))
+    new CronSpec(cronString)
   }
 
   def unapply(cronString: String): Option[CronSpec] = {
     try {
-      Some(new CronSpec(new CronParser(cronDefinition).parse(cronString)))
+      Some(new CronSpec(cronString))
     } catch {
       case NonFatal(_) => None
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,7 +45,7 @@ object Build extends sbt.Build {
         Dependency.macWireUtil,
         Dependency.macWireProxy,
         Dependency.yaml,
-        Dependency.cronUtils,
+        Dependency.cron4J,
         Dependency.metrics,
         Dependency.jsonValidate,
         Dependency.Test.scalatest,
@@ -65,7 +65,7 @@ object Build extends sbt.Build {
         Dependency.macWireMacros,
         Dependency.macWireUtil,
         Dependency.macWireProxy,
-        Dependency.cronUtils,
+        Dependency.cron4J,
         Dependency.akka,
         Dependency.metrics,
         Dependency.Test.akkaTestKit,
@@ -131,7 +131,7 @@ object Build extends sbt.Build {
       val MacWire = "2.2.2"
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
-      val CronUtils = "4.1.0"
+      val Cron4J = "2.2.5"
       val WixAccord = "0.5"
       val Akka = "2.3.15"
       val Mockito = "2.0.54-beta"
@@ -148,7 +148,7 @@ object Build extends sbt.Build {
     val macWireProxy = "com.softwaremill.macwire" %% "proxy" % V.MacWire
     val marathon = "mesosphere.marathon" %% "marathon" % V.Marathon exclude("com.typesafe.play", "*") exclude("mesosphere.marathon", "ui") exclude("mesosphere", "chaos") exclude("org.apache.hadoop", "hadoop-hdfs") exclude("org.apache.hadoop", "hadoop-common") exclude("org.eclipse.jetty", "*")
     val marathonPlugin = "mesosphere.marathon" %% "plugin-interface" % V.Marathon
-    val cronUtils = "com.cronutils" % "cron-utils" % V.CronUtils
+    val cron4J = "it.sauronsoftware.cron4j" % "cron4j" % V.Cron4J
     val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
     val akka = "com.typesafe.akka" %%  "akka-actor" % V.Akka
     val metrics = "nl.grons" %% "metrics-scala" % V.Metrics


### PR DESCRIPTION
Move from cron-utils to cron4j.   The only reason we need cron is for the "nextExecutionTime".   This is the weakest and broken part of cron-utils.  This is unfortunate as cron-utils is under active development.   All cron tests work for cron4j.     The challenge is that it is LGPL (which is fine and does not affect our project license) and it is NOT actively developed.

I might spend time at some point and fix cron-utils... for now this unblocks cron schedule issues with metronome.

The movement to cron4j is to fix the following issues:
* https://github.com/jmrozanec/cron-utils/issues/228
* https://github.com/jmrozanec/cron-utils/issues/223

These issues resulted in the following PRs to the project:
* https://github.com/jmrozanec/cron-utils/pull/224
* https://github.com/jmrozanec/cron-utils/pull/229
