### PR TITLE
Upgrading to Cron-Utils 6.0.4

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -1,12 +1,8 @@
 package dcos.metronome.api.v1
 
-import java.time.{ LocalDateTime, Month, ZoneId }
-import java.util.Date
-
 import dcos.metronome.api.v1.models._
 import dcos.metronome.model.CronSpec
 import dcos.metronome.utils.test.Mockito
-import it.sauronsoftware.cron4j.Predictor
 import org.joda.time.DateTime
 import org.scalatest.{ FunSuite, Matchers }
 import play.api.libs.json.Json

--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -1,8 +1,13 @@
 package dcos.metronome.api.v1
 
+import java.time.{ LocalDateTime, Month, ZoneId }
+import java.util.Date
+
 import dcos.metronome.api.v1.models._
 import dcos.metronome.model.CronSpec
 import dcos.metronome.utils.test.Mockito
+import it.sauronsoftware.cron4j.Predictor
+import org.joda.time.DateTime
 import org.scalatest.{ FunSuite, Matchers }
 import play.api.libs.json.Json
 
@@ -59,5 +64,82 @@ class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
     spec.toString shouldEqual cronString
 
     Json.toJson(spec).as[CronSpec] shouldEqual spec
+  }
+
+  test("First Monday Of The Month") {
+    val cronString = "0 9 1-7 * 1"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 11, 6, 9, 0)
+  }
+
+  test("Each weekday the first week Of The Month") {
+    val cronString = "0 9 1-7 * 1-5"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 3, 9, 0)
+  }
+
+  test("Each weekend day the first week Of The Month") {
+    val cronString = "0 9 1-7 * 6-7"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 7, 9, 0)
+  }
+
+  test("Each weekday the second week Of The Month") {
+    val cronString = "0 9 8-14 * 1-5"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 9, 9, 0)
+  }
+
+  test("Each weekend day the fourth week Of The Month") {
+    val cronString = "0 9 22-28 * 6-7"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 22, 9, 0)
+  }
+
+  test("Each day on a wednesday") {
+    val cronString = "* * * * 3"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 4, 0, 0)
+  }
+
+  test("Each day slash of 1 on a wednesday") {
+    val cronString = "* * */1 * 3"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2017, 10, 4, 0, 0)
   }
 }

--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -4,10 +4,21 @@ import dcos.metronome.api.v1.models._
 import dcos.metronome.model.CronSpec
 import dcos.metronome.utils.test.Mockito
 import org.joda.time.DateTime
-import org.scalatest.{ FunSuite, Matchers }
+import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
+import org.threeten.bp.zone.{ TzdbZoneRulesProvider, ZoneRulesProvider }
 import play.api.libs.json.Json
 
-class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
+class CronSpecFormatTest extends FunSuite with Mockito with Matchers with BeforeAndAfterAll {
+
+  override def beforeAll(): Unit = {
+    try {
+      val tzUrl = ClassLoader.getSystemResource("org/threeten/bp/TZDB.dat")
+      val tzProvider = new TzdbZoneRulesProvider(tzUrl)
+      ZoneRulesProvider.registerProvider(tzProvider)
+    } catch {
+      case e: Throwable => println(s"TimeZone DB already loaded! Exception: $e")
+    }
+  }
 
   test("Every minute") {
     val cronString = "* * * * *"

--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -138,4 +138,22 @@ class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
 
     nextCronDate shouldEqual new DateTime(2017, 10, 4, 0, 0)
   }
+
+  test("A cron job should execute next Monday when day of week is 1") {
+    val date = (year: Int, month: Int, day: Int) => new DateTime(year, month, day, 0, 0)
+
+    // With cronutils 4.1.0, the execution date is sometimes wrong if the
+    // intended date falls on the first or last day of the month
+    val expectations = Map(
+      date(2017, 4, 25) -> date(2017, 5, 1),
+      date(2017, 7, 28) -> date(2017, 7, 31),
+      date(2017, 12, 27) -> date(2018, 1, 1),
+      date(2018, 4, 29) -> date(2018, 4, 30),
+      date(2018, 9, 30) -> date(2018, 10, 1),
+      date(2018, 12, 26) -> date(2018, 12, 31)
+    )
+    for ((fromDate, executionDate) <- expectations) {
+      CronSpec.apply("* * * * 1").nextExecution(fromDate) shouldEqual executionDate
+    }
+  }
 }

--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -4,21 +4,10 @@ import dcos.metronome.api.v1.models._
 import dcos.metronome.model.CronSpec
 import dcos.metronome.utils.test.Mockito
 import org.joda.time.DateTime
-import org.scalatest.{ BeforeAndAfterAll, FunSuite, Matchers }
-import org.threeten.bp.zone.{ TzdbZoneRulesProvider, ZoneRulesProvider }
+import org.scalatest.{ FunSuite, Matchers }
 import play.api.libs.json.Json
 
-class CronSpecFormatTest extends FunSuite with Mockito with Matchers with BeforeAndAfterAll {
-
-  override def beforeAll(): Unit = {
-    try {
-      val tzUrl = ClassLoader.getSystemResource("org/threeten/bp/TZDB.dat")
-      val tzProvider = new TzdbZoneRulesProvider(tzUrl)
-      ZoneRulesProvider.registerProvider(tzProvider)
-    } catch {
-      case e: Throwable => println(s"TimeZone DB already loaded! Exception: $e")
-    }
-  }
+class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
 
   test("Every minute") {
     val cronString = "* * * * *"

--- a/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
@@ -49,10 +49,10 @@ object CronSpec {
       .withDayOfMonth()
       .supportsHash().supportsL().supportsW().and()
       .withMonth().and()
-      .withDayOfWeek()
-      .withIntMapping(7, 0) //we support non-standard non-zero-based numbers!
+      .withDayOfWeek().withValidRange(0, 7).withMondayDoWValue(1).withIntMapping(7, 0) //we support non-standard non-zero-based numbers!
       .supportsHash().supportsL().supportsW().and()
       .withYear().optional().and()
+      .matchDayOfWeekAndDayOfMonth() // the regular UNIX cron definition permits matching either DoW or DoM
       .instance()
 
   def isValid(cronString: String): Boolean = unapply(cronString).isDefined

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -133,7 +133,7 @@ object Build extends sbt.Build {
       val MacWire = "2.2.2"
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
-      val CronUtils = "6.0.3"
+      val CronUtils = "6.0.4"
       val Threeten = "1.3.3"
       val WixAccord = "0.5"
       val Akka = "2.3.15"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,6 +47,7 @@ object Build extends sbt.Build {
         Dependency.yaml,
         Dependency.Test.threeten,
         Dependency.cronUtils,
+        Dependency.threeten,
         Dependency.metrics,
         Dependency.jsonValidate,
         Dependency.Test.scalatest,
@@ -67,6 +68,7 @@ object Build extends sbt.Build {
         Dependency.macWireUtil,
         Dependency.macWireProxy,
         Dependency.Test.threeten,
+        Dependency.threeten,
         Dependency.cronUtils,
         Dependency.akka,
         Dependency.metrics,
@@ -150,7 +152,8 @@ object Build extends sbt.Build {
     val macWireProxy = "com.softwaremill.macwire" %% "proxy" % V.MacWire
     val marathon = "mesosphere.marathon" %% "marathon" % V.Marathon exclude("com.typesafe.play", "*") exclude("mesosphere.marathon", "ui") exclude("mesosphere", "chaos") exclude("org.apache.hadoop", "hadoop-hdfs") exclude("org.apache.hadoop", "hadoop-common") exclude("org.eclipse.jetty", "*")
     val marathonPlugin = "mesosphere.marathon" %% "plugin-interface" % V.Marathon
-    val cronUtils = "com.cronutils" % "cron-utils" % V.CronUtils
+    val cronUtils = "com.cronutils" % "cron-utils" % V.CronUtils exclude("org.threeten", "threetenbp")
+    val threeten = "org.threeten" % "threetenbp" % "1.3.3"
     val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
     val akka = "com.typesafe.akka" %%  "akka-actor" % V.Akka
     val metrics = "nl.grons" %% "metrics-scala" % V.Metrics

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,7 +45,6 @@ object Build extends sbt.Build {
         Dependency.macWireUtil,
         Dependency.macWireProxy,
         Dependency.yaml,
-        Dependency.Test.threeten,
         Dependency.cronUtils,
         Dependency.threeten,
         Dependency.metrics,
@@ -67,7 +66,6 @@ object Build extends sbt.Build {
         Dependency.macWireMacros,
         Dependency.macWireUtil,
         Dependency.macWireProxy,
-        Dependency.Test.threeten,
         Dependency.threeten,
         Dependency.cronUtils,
         Dependency.akka,
@@ -136,6 +134,7 @@ object Build extends sbt.Build {
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
       val CronUtils = "6.0.3"
+      val Threeten = "1.3.3"
       val WixAccord = "0.5"
       val Akka = "2.3.15"
       val Mockito = "2.0.54-beta"
@@ -153,7 +152,7 @@ object Build extends sbt.Build {
     val marathon = "mesosphere.marathon" %% "marathon" % V.Marathon exclude("com.typesafe.play", "*") exclude("mesosphere.marathon", "ui") exclude("mesosphere", "chaos") exclude("org.apache.hadoop", "hadoop-hdfs") exclude("org.apache.hadoop", "hadoop-common") exclude("org.eclipse.jetty", "*")
     val marathonPlugin = "mesosphere.marathon" %% "plugin-interface" % V.Marathon
     val cronUtils = "com.cronutils" % "cron-utils" % V.CronUtils exclude("org.threeten", "threetenbp")
-    val threeten = "org.threeten" % "threetenbp" % "1.3.3"
+    val threeten = "org.threeten" % "threetenbp" % V.Threeten
     val wixAccord = "com.wix" %% "accord-core" % V.WixAccord
     val akka = "com.typesafe.akka" %%  "akka-actor" % V.Akka
     val metrics = "nl.grons" %% "metrics-scala" % V.Metrics
@@ -162,7 +161,6 @@ object Build extends sbt.Build {
     object Test {
       val scalatest = "org.scalatest" %% "scalatest" % V.ScalaTest % "test"
       val scalatestPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
-      val threeten = "org.threeten" % "threetenbp" % "1.3.3" % "test"
       val akkaTestKit = "com.typesafe.akka" %%  "akka-testkit" % V.Akka % "test"
       val mockito = "org.mockito" % "mockito-core" % V.Mockito % "test"
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -131,7 +131,7 @@ object Build extends sbt.Build {
       val MacWire = "2.2.2"
       val Marathon = "1.2.0-RC1"
       val Play = "2.5.3"
-      val CronUtils = "4.1.0"
+      val CronUtils = "6.0.3"
       val WixAccord = "0.5"
       val Akka = "2.3.15"
       val Mockito = "2.0.54-beta"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,6 +45,7 @@ object Build extends sbt.Build {
         Dependency.macWireUtil,
         Dependency.macWireProxy,
         Dependency.yaml,
+        Dependency.Test.threeten,
         Dependency.cronUtils,
         Dependency.metrics,
         Dependency.jsonValidate,
@@ -65,6 +66,7 @@ object Build extends sbt.Build {
         Dependency.macWireMacros,
         Dependency.macWireUtil,
         Dependency.macWireProxy,
+        Dependency.Test.threeten,
         Dependency.cronUtils,
         Dependency.akka,
         Dependency.metrics,
@@ -157,6 +159,7 @@ object Build extends sbt.Build {
     object Test {
       val scalatest = "org.scalatest" %% "scalatest" % V.ScalaTest % "test"
       val scalatestPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
+      val threeten = "org.threeten" % "threetenbp" % "1.3.3" % "test"
       val akkaTestKit = "com.typesafe.akka" %%  "akka-testkit" % V.Akka % "test"
       val mockito = "org.mockito" % "mockito-core" % V.Mockito % "test"
     }


### PR DESCRIPTION
Fixes for crons we need to support were released in the latest 6.0.3.   This however was a bigger change that needs some review.  It required:

* update to dates used and the use of optional
* changes to the cron def 

The backward compatibility of the CronSpec regarding Dates is intentional.   The cost to change Dates across the entire project is extensive.   This lead to isolating the need Date library to CronSpec.   

This enabled a minimum impact fix to update to the latest cron-utils and gain the value of confirming previous cron tests passed with no changes.

This now supersedes PR https://github.com/dcos/metronome/pull/136 which will be closed.

