### PR TITLE
Pipeline build, test and release of Metronome added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ project/plugins/project/
 
 # python
 *.pyc
+
+sandboxes.tar.gz

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,60 @@
+# Marathon CI pipeline
+
+In order to be CI tool agnostic and provide the benefit of running all CI tasks
+on a "local" machine, the marathon team has moved to using [Ammonite](http://www.lihaoyi.com/Ammonite/)
+for CI pipelining tasks.   Ammonite is a Scala based scripting tool and is
+easiest to install on a Mac with `brew install ammonite-repl`.  Other platforms
+please read the Ammonite site.   The `ci` folder in the root project contains
+the ammonite scripts.   The script requires the project build requirements such
+as a JDK, Scala and sbt in the path.
+
+
+## Using Ammonite
+
+The ammonite script is a runnable script.  To get a list of functions to invoke execute: `./ci/pipeline`
+
+To execute a particular function just invoke the script with function appended as in:
+`./ci/pipeline compileAndTest` which will compile and test the marathon project.
+
+## Pipeline Targets
+
+The `ci/pipeline` script defines two primary targets
+
+1. `jenkins`
+
+The `jenkins` target is executed on every branch build by jenkins. It runs
+
+  * `compileAndTest()`
+  * `createPackages()`
+
+
+## Sub Targets
+
+The `provision.*` targets prepare the Jenkins AWS nodes by killing leak
+processes from older test runs and updating Mesos. You can run them locally but
+be careful. The `killStaleTestProcesses` might kill process you don't want to be
+gone.
+
+The `compileAndTest` target basically runs `sbt clean test`. This is the main compilation step.
+
+The `createPackages` target assembles Marathon binary packages and generates the
+sha1 checksums for the zip and tarball packages. See `createPackageSha1s` in the
+code base for details.
+
+There are several targets in `githubClient`:
+
+  * `reject`
+  * `comment`
+  * `collectTestResults`
+  * `reportSuccess`
+  * `reportFailure`
+
+Method `reject` and `reportFailure` rejects a GitHub pull request review while `reportSuccess` approves it.
+The `comment` method posts a comment to the pull request.
+`collectTestResults` gathers and returns unit and integration test results. It checks `target/phabricator-test-reports/`
+for JSON files and joins them.
+
+One can comment from the CLI with
+```
+amm ./ci/githubClient.sc comment 777 "test from pipeline"
+```

--- a/ci/awsClient.sc
+++ b/ci/awsClient.sc
@@ -1,0 +1,117 @@
+#!/usr/bin/env amm
+
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+
+import $ivy.`com.amazonaws:aws-java-sdk-s3:1.11.129`
+
+import $file.fileUtil
+
+import com.amazonaws.services.s3._
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.transfer._
+import com.amazonaws.services.s3.transfer.Transfer.TransferState
+import com.amazonaws.services.s3.model.{PutObjectRequest, CannedAccessControlList}
+import scala.collection.JavaConversions._
+
+/**
+ * Describes an S3 location.
+ */
+case class S3Path(bucket: String, path: Path) {
+  override def toString(): String = s"s3://${bucket}${path}"
+  def /(component: String): S3Path = copy(path = path / component)
+  def key: String = path.relativeTo(Path("/")).toString
+}
+
+/**
+ * Describes an artifact.
+ *
+ * @param path S3 path for artifact.
+ * @param sha1 The checksum of the artifact.
+ */
+case class Artifact(path: S3Path, sha1: String) {
+
+  val base = "https://s3.amazonaws.com"
+
+  /**
+   * @return download url.
+   */
+  def downloadUrl: String = s"$base/${path.bucket}/${path.key}"
+}
+
+val S3_PREFIX = S3Path(
+  sys.env.getOrElse("S3_BUCKET", "downloads.mesosphere.io"),
+  Path(sys.env.getOrElse("S3_PATH" , "/metronome/snapshots")))
+
+/**
+ *  Returns AWS S3 client.
+ */
+def createS3Client(): AmazonS3Client = {
+  new AmazonS3Client(new DefaultAWSCredentialsProviderChain())
+}
+
+/**
+ *  Returns True if the key is in the bucket
+ */
+def doesS3FileExist(path: S3Path): Boolean = {
+  val s3client = createS3Client()
+  s3client.doesObjectExist(path.bucket, path.key)
+}
+
+/**
+ *  Uploads marathon artifacts to the default bucket, using the env var credentials.
+ *  Upload process creates the sha1 file.
+ *  If file name is on s3, it does NOT upload (these files are big). We cannot
+ *  compare the sha1 sums because they change for each build of the same commit.
+ *  However, our artifact names are unique for each commit.
+ *
+ *  @return Artifact description if it was uploaded. None otherwise.
+ */
+def archiveArtifact(uploadFile: Path): Option[Artifact] = {
+  // is already uploaded.
+  if(doesS3FileExist(S3_PREFIX / uploadFile.last)) {
+    println(s"Skipping File: ${uploadFile.last} already exists on S3 at ${S3_PREFIX / uploadFile.last}")
+    None
+  } else
+    Some(uploadFileAndSha(uploadFile))
+}
+
+/**
+ *  Uploads marathon artifacts to the default bucket, using the env var credentials.
+ *  Upload process creates the sha1 file
+ */
+def uploadFileAndSha(uploadFile: Path): Artifact = {
+  val shaFile = fileUtil.writeSha1ForFile(uploadFile)
+
+  upload(uploadFile)
+  upload(shaFile)
+  Artifact(S3_PREFIX / uploadFile.last, read(shaFile))
+}
+
+/**
+ * Uploads file to default bucket.
+ */
+def upload(file: Path): Unit = {
+  uploadFileToS3(file, S3_PREFIX / file.last)
+}
+
+/**
+ *  Uploads a file to the S3 bucket
+ */
+def uploadFileToS3(localFile: Path, remotePath: S3Path): Unit = {
+  val transfer: TransferManager = TransferManagerBuilder.standard().withS3Client(createS3Client()).build()
+  val request = new PutObjectRequest(remotePath.bucket, remotePath.key, localFile.toIO)
+  request.withCannedAcl(CannedAccessControlList.PublicRead)
+  val upload: Upload = transfer.upload(request)
+
+  println(s"Uploading ${localFile} -> ${remotePath}")
+  while(!upload.isDone()) {
+    val progress = upload.getProgress()
+    println(s"Uploading ${localFile} -> ${remotePath}: ${progress.getPercentTransferred()} % ${upload.getState()}")
+    Thread.sleep(2000)
+  }
+
+  transfer.shutdownNow(true)
+  assert(upload.getState() == TransferState.Completed, s"Upload finished with ${upload.getState()}")
+  println(s"Uploading ${localFile} -> ${remotePath}: Finished")
+}

--- a/ci/fileUtil.sc
+++ b/ci/fileUtil.sc
@@ -1,0 +1,53 @@
+#!/usr/bin/env amm
+
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+
+import java.security.MessageDigest
+import javax.xml.bind.annotation.adapters.HexBinaryAdapter
+
+val SHA_EXTENSION = "sha1"
+
+/**
+ * Creates the SHA-1 for a given file
+ */
+def createSha1OfFile(file: Path): String = {
+  val sha1 = MessageDigest.getInstance("SHA-1");
+  sha1.update(read.bytes! file)
+  (new HexBinaryAdapter().marshal(sha1.digest())).toLowerCase
+}
+
+/**
+ * Creates a SHA-1 file for a give file.
+ * Given a file "foo.txt", a "foo.txt.sha1" will be created with the sha.
+ */
+def writeSha1ForFile(file: Path): Path = {
+  val sha1File = getShaPathForFile(file)
+  rm! sha1File
+  write(sha1File, createSha1OfFile(file))
+  sha1File
+}
+
+/**
+ * Gets the path of the sha file for a give path
+ */
+def getShaPathForFile(file: Path): Path = {
+  (file / up) / (s"${file.last}.$SHA_EXTENSION")
+}
+
+/**
+ * Gets the path of the temp sha file for a give path.
+ * Temp file is used for slower writing processes such as a download.
+ */
+def withTempFileFor[T](file: Path)(block: Path => T): T = {
+  val tmpFile = (file / up) / (s"${file.last}.tmp")
+  try { block(tmpFile) }
+  finally { rm! tmpFile }
+}
+
+/**
+ * Temp file is used for slower writing processes such as a download.
+ */
+def withTempFile[T](block: Path => T): T = {
+  withTempFileFor ((pwd) / (s"s3.tmp"))(block)
+}

--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -1,0 +1,178 @@
+#!/usr/bin/env amm
+
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+
+import $file.utils
+import $file.awsClient
+
+import scala.util.control.NonFatal
+import scalaj.http._
+import upickle._
+
+/**
+ * Makes a POST request to GitHub's API with path and body.
+ * E.g. "repos/mesosphere/marathon/pulls/5513/reviews" would post the body as a
+ * comment.
+ *
+ * @param path The API path. See path in
+ *   https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+ *   for an example.
+ * @param body The body of the post request.
+ */
+def execute(path:String, body: String): Unit = {
+  val GITHUB_API_TOKEN =
+    sys.env.getOrElse("GIT_PASSWORD", throw new IllegalArgumentException("GIT_PASSWORD enviroment variable was not set."))
+  val GITHUB_API_USER =
+    sys.env.getOrElse("GIT_USER", throw new IllegalArgumentException("GIT_USER enviroment variable was not set."))
+
+  val response = Http(s"https://api.github.com/$path")
+    .auth(GITHUB_API_USER, GITHUB_API_TOKEN)
+    .timeout(connTimeoutMs = 5000, readTimeoutMs = 100000)
+    .postData(body)
+    .asString
+    .throwError
+}
+
+/**
+ * Comment with msg on pull request with pullNumber.
+ */
+def comment(pullNumber: String, msg: String, event: String = "COMMENT"): Unit = {
+  val request = Js.Obj(
+    "body"  -> Js.Str(msg),
+    "event" -> Js.Str(event)
+    )
+  val path = s"repos/mesosphere/marathon/pulls/$pullNumber/reviews"
+  execute(path, request.toString)
+}
+
+/**
+ * Reject pull request with pullNumber.
+ */
+def reject(
+  pullNumber: String,
+  buildUrl: String,
+  buildTag: String): Unit = {
+  val msg = s"I'm building your change at [$buildTag]($buildUrl)."
+
+  comment(pullNumber, msg, "REQUEST_CHANGES")
+}
+
+/**
+ * Collect test results.
+ *
+ * @return the parsed test results.
+ */
+@main
+def collectTestResults(): Js.Arr = {
+
+  try {
+    // Join all results
+    val testResults = ls! pwd / 'target / "phabricator-test-reports" |? ( _.ext == "json")
+    val joinedTestResults: Js.Arr = testResults.view.map(read!)
+      .map(upickle.json.read)
+      .collect { case a: Js.Arr => a }
+      .reduce { (l: Js.Arr, r: Js.Arr) =>
+        val n = l.arr ++ r.arr
+        Js.Arr(n :_*)
+      }
+
+    joinedTestResults
+  } catch {
+    case NonFatal(e) =>
+      utils.printlnWithColor(s"Could not collect test results: ${e.getMessage}", utils.Colors.BrightRed)
+      Js.Arr()
+  }
+}
+
+/**
+ * Report success of diff build back to GitHub.
+ *
+ * @param pullNumber The pull request of the build.
+ * @param buildUrl A link back to the build on Jenkins.
+ * @param buildTag Identifies build.
+ * @param maybeArtifact A description of the Marathon binary that has been uploaded.
+ *    It's None when now package was uploaded.
+ */
+def reportSuccess(
+  pullNumber: String,
+  buildUrl: String,
+  buildTag: String,
+  maybeArtifact: Option[awsClient.Artifact]): Unit = {
+
+  val testResults = collectTestResults()
+
+  // Collect unsound, i.e. canceled, tests
+  val unsoundTests = testResults.value
+    .collect { case test: Js.Obj if test("result").value == "unsound" => test  }
+  val hasUnsoundTests = unsoundTests.nonEmpty
+
+  // Construct message
+  val buildinfoDiff = maybeArtifact.fold(""){ artifact =>
+    s"""
+      |```json
+      |"url": "${artifact.downloadUrl}",
+      |"sha1": "${artifact.sha1}"
+      |```
+     """.stripMargin
+  }
+
+  var msg = s"""
+    |**\u2714 Build of #$pullNumber completed successfully.**
+    |
+    |See details at [$buildTag]($buildUrl).
+    |
+    |You can create a DC/OS with your patched Marathon by creating a new pull
+    |request with the following changes in [buildinfo.json](https://github.com/dcos/dcos/blob/master/packages/marathon/buildinfo.json):
+    |
+    |$buildinfoDiff
+    |
+    |""".stripMargin
+
+  if (!hasUnsoundTests) {
+    msg += "**＼\\ ٩( ᐛ )و /／**"
+  } else {
+    val unsoundTestsList: String = unsoundTests.foldLeft("") { (msg:String, test: Js.Obj) =>
+      msg + s"""\n- `${test("name").value}`"""
+    }
+
+    msg += s"""
+    |The following tests failed and have been marked as canceled. Are you sure you want to land this patch?
+    | $unsoundTestsList
+    |
+    |Anyhow, check the [skipped tests]($buildUrl/testReport) on Jenkins for details and decide for yourself.
+    |
+    |**¯\\_(ツ)_/¯**
+    |""".stripMargin
+  }
+
+  comment(pullNumber, msg, event="APPROVE")
+}
+
+/**
+ * Report failure of build back to GitHub.
+ *
+ * @param pullNumber The pull request of the build.
+ * @param buildUrl A link back to the build on Jenkins.
+ * @param buildTag Identifies build.
+ * @param msg The error message for the failure.
+ */
+def reportFailure(
+  pullNumber: String,
+  buildUrl: String,
+  buildTag: String,
+  msg: String) : Unit = {
+
+  val body = s"""
+    |**\u2717 Build of #$pullNumber failed.**
+    |
+    |See the [logs]($buildUrl/console) and [test results]($buildUrl/testReport) for details.
+    |
+    |Error message:
+    |>$msg
+    |
+    |**(๑′°︿°๑)**
+    |""".stripMargin
+
+  comment(pullNumber, body, event="REQUEST_CHANGES")
+}

--- a/ci/githubClient.sc
+++ b/ci/githubClient.sc
@@ -12,7 +12,7 @@ import upickle._
 
 /**
  * Makes a POST request to GitHub's API with path and body.
- * E.g. "repos/mesosphere/marathon/pulls/5513/reviews" would post the body as a
+ * E.g. "repos/dcos/metronome/pulls/5513/reviews" would post the body as a
  * comment.
  *
  * @param path The API path. See path in
@@ -42,7 +42,7 @@ def comment(pullNumber: String, msg: String, event: String = "COMMENT"): Unit = 
     "body"  -> Js.Str(msg),
     "event" -> Js.Str(event)
     )
-  val path = s"repos/mesosphere/marathon/pulls/$pullNumber/reviews"
+  val path = s"repos/dcos/metronome/pulls/$pullNumber/reviews"
   execute(path, request.toString)
 }
 
@@ -91,7 +91,7 @@ def collectTestResults(): Js.Arr = {
  * @param pullNumber The pull request of the build.
  * @param buildUrl A link back to the build on Jenkins.
  * @param buildTag Identifies build.
- * @param maybeArtifact A description of the Marathon binary that has been uploaded.
+ * @param maybeArtifact A description of the Metronome binary that has been uploaded.
  *    It's None when now package was uploaded.
  */
 def reportSuccess(
@@ -122,8 +122,8 @@ def reportSuccess(
     |
     |See details at [$buildTag]($buildUrl).
     |
-    |You can create a DC/OS with your patched Marathon by creating a new pull
-    |request with the following changes in [buildinfo.json](https://github.com/dcos/dcos/blob/master/packages/marathon/buildinfo.json):
+    |You can create a DC/OS with your patched Metronome by creating a new pull
+    |request with the following changes in [buildinfo.json](https://github.com/dcos/dcos/blob/master/packages/metronome/buildinfo.json):
     |
     |$buildinfoDiff
     |

--- a/ci/launch_cluster.sh
+++ b/ci/launch_cluster.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -x -e -o pipefail
+
+# Two parameters are expected: CHANNEL and VARIANT where CHANNEL is the respective PR and
+# VARIANT could be one of four custer variants: open, strict, permissive and disabled
+if [ "$#" -ne 2 ]; then
+    echo "Expected 2 parameters: <channel> and <variant> e.g. launch_cluster.sh testing/pull/1739 open"
+    exit 1
+fi
+
+CHANNEL="$1"
+VARIANT="$2"
+
+JOB_NAME_SANITIZED=$(echo "$JOB_NAME" | tr -c '[:alnum:]-' '-')
+DEPLOYMENT_NAME="$JOB_NAME_SANITIZED-$(date +%s)"
+
+if [ "$VARIANT" == "open" ]; then
+  TEMPLATE="https://s3.amazonaws.com/downloads.dcos.io/dcos/${CHANNEL}/cloudformation/single-master.cloudformation.json"
+else
+  TEMPLATE="https://s3.amazonaws.com/downloads.mesosphere.io/dcos-enterprise-aws-advanced/${CHANNEL}/${VARIANT}/cloudformation/ee.single-master.cloudformation.json"
+fi
+
+echo "Workspace: ${WORKSPACE}"
+echo "Using: ${TEMPLATE}"
+
+apk update
+apk --upgrade add gettext wget
+wget 'https://downloads.dcos.io/dcos-test-utils/bin/linux/dcos-launch' && chmod +x dcos-launch
+
+
+envsubst <<EOF > config.yaml
+---
+launch_config_version: 1
+template_url: $TEMPLATE
+deployment_name: $DEPLOYMENT_NAME
+provider: aws
+aws_region: us-west-2
+template_parameters:
+    DefaultInstanceType: m4.large
+    KeyName: default
+    AdminLocation: 0.0.0.0/0
+    PublicSlaveInstanceCount: 1
+    SlaveInstanceCount: 5
+EOF
+
+function create-junit-xml {
+    local testsuite_name=$1
+    local testcase_name=$2
+    local error_message=$3
+
+	cat > shakedown.xml <<-EOF
+	<testsuites>
+	  <testsuite name="$testsuite_name" errors="0" skipped="0" tests="1" failures="1">
+	      <testcase classname="$testsuite_name" name="$testcase_name">
+	        <failure message="test setup failed">$error_message</failure>
+	      </testcase>
+	  </testsuite>
+	</testsuites>
+	EOF
+}
+
+if ! ./dcos-launch create; then
+  create-junit-xml "dcos-launch" "cluster.create" "Cluster launch failed."
+  exit 1
+fi
+if ! ./dcos-launch wait; then
+  create-junit-xml "dcos-launch" "cluster.create" "Cluster did not start in time."
+  exit 1
+fi
+
+# Return dcos_url
+echo "http://$(./dcos-launch describe | jq -r ".masters[0].public_ip")/"

--- a/ci/pipeline
+++ b/ci/pipeline
@@ -1,0 +1,150 @@
+#!/usr/bin/env amm
+
+// Get a logging backend into classpath.
+import $ivy.`org.slf4j:slf4j-simple:1.7.25`
+
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+import scala.util.Try
+
+import $file.awsClient
+import $file.fileUtil
+import $file.githubClient
+import $file.utils
+
+val PACKAGE_DIR: Path = pwd / 'target / 'universal
+
+/**
+ * Compile Metronome and run unit and integration tests followed by scapegoat.
+ */
+@main
+def compileAndTest(): Unit = utils.stage("Compile and Test") {
+
+  def run(cmd: String *) = utils.runWithTimeout(1.hour)(cmd)
+
+  run("sbt", "clean", "test")
+}
+
+@main
+def zipSandboxLogs(): Unit = {
+  Try(%("tar", "-zcf", "sandboxes.tar.gz", "sandboxes"))
+}
+
+@main
+/**
+ * Upload Metronome tgz tarballs and its cha1 checksum to S3.
+ *
+ * @return Artifact description if it was uploaded.
+ */
+def uploadTarballToS3(): Option[awsClient.Artifact] = utils.stage("Upload Packages") {
+  import scala.collection.breakOut
+
+  PACKAGE_DIR.toIO.listFiles.filter(f => f.getName.endsWith(".tgz"))
+    .headOption.flatMap(file => awsClient.archiveArtifact(Path(file)))
+}
+
+@main
+/**
+ * Packages Metronome and uploads its artifacts alongside sha1 checksum to S3.
+ *
+ * @return Version and artifact description of Metronome build.
+ */
+def createAndUploadPackages(): (String, Option[awsClient.Artifact]) = {
+  val version = createPackages()
+  val artifact = uploadTarballToS3()
+
+  createDocker()
+  (version, artifact)
+}
+
+/**
+ * Creates the zip and txz files of the Metronome runnable package with their
+ * associated sha1
+ *
+ * @return version of build.
+ */
+@main
+def createPackages(): String = utils.stage("Package") {
+  val result = %%('sbt, "universal:packageZipTarball", "version")
+
+  // Regex is for version:
+  // starting with random chars, match $number$dot$number$dot$number followed by optional alpha numberic chars plus `-`
+  // ending with random characters
+  // we need to regex this string because we do have colored output in the `sbt version` command
+  val VersionLineRegex = "^.*(\\d+\\.\\d+\\.\\d+[-A-Za-z\\d]+).*$".r
+
+  // Nothing is what it seems. This is a poor man's way to extract the version
+  // from sbt's console output until we run our Ammonite scripts in sbt.
+  val version = result.out.lines.last match {
+    case VersionLineRegex(v) => v
+    case _ =>
+        val commit = %%('git, "log", "--pretty=format:%h", "-n1").out.lines.last
+        s"unkown version in commit $commit"
+  }
+  println(s"Built tarballs for Metronome $version.")
+  version
+}
+
+/**
+ * Create Docker, rpm and deb packages.
+ */
+@main
+def createDocker(): Unit = utils.stage("Package Docker Image, Debian and RedHat Packages") {
+  %('sbt, "docker:publishLocal")
+}
+
+/**
+ * The pipeline target for GitHub pull request builds. It wraps other targets
+ * and does some additional reporting to GitHub.
+ */
+def asPullRequest(run: => (String, Option[awsClient.Artifact])): Unit = {
+  val pullNumber: String = sys.env.getOrElse("CHANGE_ID", throw new IllegalArgumentException("No CHANGE_ID was defined."))
+  val buildUrl: String = sys.env.getOrElse("BUILD_URL", throw new IllegalArgumentException("No BUILD_URL was defined."))
+  val buildTag: String = sys.env.getOrElse("BUILD_TAG", "here")
+
+  try {
+    githubClient.reject(pullNumber, buildUrl, buildTag)
+    val (_, maybeArtifact) = run
+    githubClient.reportSuccess(pullNumber, buildUrl, buildTag, maybeArtifact)
+  } catch {
+    case NonFatal(e) =>
+      githubClient.reportFailure(pullNumber, buildUrl, buildTag, e.getMessage())
+      throw e
+  }
+}
+
+/**
+ * Run the main pipeline.
+ *
+ * @return Version and artifact description of Metronome build.
+ */
+@main
+def run(): (String, Option[awsClient.Artifact]) = {
+
+  try {
+    compileAndTest()
+  } finally {
+    zipSandboxLogs()    // Try to archive logs in any case
+  }
+
+  val (version, maybeArtifact) = createAndUploadPackages()
+
+  (version, maybeArtifact)
+}
+
+/**
+ * The main pipeline target for builds on Jenkins.
+ *
+ * @return Version and artifact description of Metronome build.
+ */
+@main
+def jenkins(): Unit = {
+  if(utils.isPullRequest) {
+    asPullRequest { run() }
+  } else {
+    run()
+  }
+}

--- a/ci/system_integration.sh
+++ b/ci/system_integration.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Expected 1 parameter: <dcos_url> e.g. system_integration.sh http://..."
+    exit 1
+fi
+
+DCOS_URL="$1"
+cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"
+
+TERM=velocity shakedown \
+  --stdout all \
+  --stdout-inline \
+  --ssl-no-verify \
+  --timeout 360000 \
+  --pytest-option "--junitxml=shakedown.xml" \
+  --pytest-option --verbose \
+  --pytest-option --full-trace \
+  --ssh-key-file "$CLI_TEST_SSH_KEY" \
+  --dcos-url "$DCOS_URL" tests/system

--- a/ci/utils.sc
+++ b/ci/utils.sc
@@ -1,0 +1,149 @@
+// A collection of pipeline utilities such as stage names and colors.
+
+import ammonite.ops._
+import ammonite.ops.ImplicitWd._
+import java.util.concurrent.TimeUnit
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+import scala.util.control.NonFatal
+
+
+// Color definitions
+object Colors {
+  val BrightRed = "\u001b[31;1m"
+  val BrightGreen = "\u001b[32;1m"
+  val BrightBlue = "\u001b[34;1m"
+  val Reset = "\u001b[0m"
+}
+
+def printWithColor(text: String, color: String): Unit = {
+  print(color)
+  print(text)
+  print(Colors.Reset)
+}
+
+def printlnWithColor(text: String, color: String): Unit = printWithColor(s"$text\n", color)
+
+def printHr(color: String, character: String = "*", length: Int = 80): Unit = {
+  printWithColor(s"${character * length}\n", color)
+}
+
+def printStageTitle(name: String): Unit = {
+  val indent = (80 - name.length) / 2
+  print("\n")
+  print(" " * indent)
+  printWithColor(s"$name\n", Colors.BrightBlue)
+  printHr(Colors.BrightBlue)
+}
+
+case class BuildException(val cmd: String, val exitValue: Int, private val cause: Throwable = None.orNull)
+  extends Exception(s"'$cmd' exited with $exitValue", cause)
+case class StageException(private val message: String = "", private val cause: Throwable = None.orNull)
+  extends Exception(message, cause)
+def stage[T](name: String)(block: => T): T = {
+  printStageTitle(name)
+
+  try {
+    block
+  }
+  catch { case NonFatal(e) =>
+    throw new StageException(s"Stage $name failed.", e)
+  }
+}
+
+/**
+ * Run a process with given commands and time out it runs too long.
+ *
+ * @param timeout The maximum time to wait.
+ * @param commands The commands that are executed in a process. E.g. "sbt",
+ *  "compile".
+ */
+def runWithTimeout(timeout: FiniteDuration)(commands: Seq[String]): Unit = {
+
+  val builder = new java.lang.ProcessBuilder()
+  val buildProcess = builder
+    .directory(new java.io.File(pwd.toString))
+    .command(commands.asJava)
+    .inheritIO()
+    .start()
+
+  try {
+    val exited = buildProcess.waitFor(timeout.length, timeout.unit)
+
+    if (exited) {
+      val exitValue = buildProcess.exitValue
+      if(buildProcess.exitValue != 0) {
+        val cmd = commands.mkString(" ")
+        throw new utils.BuildException(cmd, exitValue)
+      }
+    } else {
+      // The process timed out. Try to kill it.
+      buildProcess.destroyForcibly().waitFor()
+      val cmd = commands.mkString(" ")
+      throw new java.util.concurrent.TimeoutException(s"'$cmd' timed out after $timeout.")
+    }
+  } finally {
+    // This also cleans forked SBT processes.
+    killStaleTestProcesses()
+  }
+}
+
+/**
+ * Kill stale processes from previous pipeline runs.
+ */
+@main
+def killStaleTestProcesses(): Unit = {
+  def protectedProcess(proc: String): Boolean =
+    Vector("slave.jar", "grep", "amm", "ci/pipeline").exists(proc.contains)
+
+  def eligibleProcess(proc: String): Boolean =
+    Vector("app_mock", "mesos", "java").exists(proc.contains)
+
+  def processesToKill() = %%('ps, 'aux).out.lines.filter { proc =>
+    eligibleProcess(proc) && !protectedProcess(proc)
+  }
+
+  val leaks = processesToKill()
+
+  if (leaks.isEmpty) {
+    println("No leaked processes detected")
+  } else {
+    println("This requires root permissions. If you run this on a workstation it'll kill more than you expect.\n")
+    println(s"Will kill:")
+    leaks.foreach( p => println(s"  $p"))
+
+    val pidPattern = """([^\s]+)\s+([^\s]+)\s+.*""".r
+
+    val pids = leaks.map {
+      case pidPattern(_, pid) => pid
+    }
+
+    println(s"Running 'sudo kill -9 ${pids.mkString(" ")}")
+
+    // We use %% to avoid exceptions. It is not important if the kill fails.
+    try { %%('sudo, 'kill, "-9", pids) }
+    catch { case e => println(s"Could not kill stale process.") }
+
+    // Print stale processes if any exist to see what couldn't be killed:
+    val undead = processesToKill()
+    if (undead.nonEmpty) {
+      println("Couldn't kill some leaked processes:")
+      undead.foreach( p => println(s"  $p"))
+    }
+  }
+}
+
+/**
+ * @return True if build is on master build.
+ */
+def isMasterBuild(): Boolean = {
+  sys.env.get("JOB_NAME").contains("marathon-pipelines/master")
+}
+
+/**
+ * @return True if build is for pull request.
+ */
+def isPullRequest(): Boolean = {
+  val pr = """marathon-pipelines/PR-(\d+)""".r
+  sys.env.get("JOB_NAME").collect { case pr(_) => true }.getOrElse(false)
+}


### PR DESCRIPTION
These are consistent with marathon's `ci/pipeline` capabilities.

`ci/pipeline compileAndTest` - compiles and tests
`ci/pipeline createAndUploadPackages` - creates release package and uploads to s3
`ci/pipeline createDocker` - creates docker image
