### PR TITLE
Update generated API documentation

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -205,7 +205,7 @@
             "type": "string",
             "description": "Cron based schedule string."
           },
-          "timeZone": {
+          "timezone": {
             "type": "string",
             "description": "IANA based time zone string. See http://www.iana.org/time-zones for a list of available time zones."
           },

--- a/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
@@ -18,7 +18,7 @@
       "type": "string",
       "description": "Cron based schedule string."
     },
-    "timeZone": {
+    "timezone": {
       "type": "string",
       "description": "IANA based time zone string. See http://www.iana.org/time-zones for a list of available time zones."
     },


### PR DESCRIPTION
'timezone' instead of 'timeZone'.

When trying to submit to the API using 'timeZone', the request was accepted (no 40x error), but the value ignored (remained as UTC).

Using 'timezone' worked fine.