### PR TITLE
TaskKill Retry Max was removed from marathon.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -476,6 +476,11 @@ metronome {
   }
 
   web.ui.url = ${?METRONOME_WEB_UI_URL}
+
+  killtask {
+    kill_chunk_size = ${?METRONOME_KILLTASK_KILL_CHUNKSIZE}
+    kill_retry_timeout = ${?METRONOME_KILLTASK_KILL_RETRY_TIMEOUT}
+  }
 }
 
 # Don't create a pidfile in the file system

--- a/src/main/scala/dcos/metronome/MetronomeConfig.scala
+++ b/src/main/scala/dcos/metronome/MetronomeConfig.scala
@@ -48,7 +48,6 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
 
   lazy val killChunkSize: Int = configuration.getInt("metronome.killtask.kill_chunk_size").getOrElse(100)
   lazy val killRetryTimeout: Long = configuration.getLong("metronome.killtask.kill_retry_timeout").getOrElse(10.seconds.toMillis)
-  lazy val killRetryMax: Int = configuration.getInt("metronome.killtask.kill_retry_max").getOrElse(5)
 
   lazy val httpScheme: String = httpPort.map(_ => "http").getOrElse("https")
   lazy val webuiURL: String = configuration.getString("metronome.web.ui.url").getOrElse(s"$httpScheme://$hostnameWithPort")
@@ -90,8 +89,7 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
       "--task_lost_expunge_initial_delay" -> Some(taskLostExpungeInitialDelay.toMillis.toString),
       "--task_lost_expunge_interval" -> Some(taskLostExpungeInterval.toMillis.toString),
       "--kill_chunk_size" -> Some(killChunkSize.toString),
-      "--kill_retry_timeout" -> Some(killRetryTimeout.toString),
-      "--kill_retry_max" -> Some(killRetryMax.toString)
+      "--kill_retry_timeout" -> Some(killRetryTimeout.toString)
     )
       .collect { case (name, Some(value)) => (name, value) }
       .flatMap { case (name, value) => Seq(name, value) }


### PR DESCRIPTION
adding taskkill configs to the application conf and removing kill-retry-max as it was removed from marathon 1.3.13