### PR TITLE
Make it possible to enable framework authentication in metronome

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -386,7 +386,7 @@ metronome {
 
   mesos {
     #  (Optional Default: false) Enable framework authentication.
-    authentication = ${?METRONOME_MESOS_AUTHENTICATION}
+    authentication.enabled = ${?METRONOME_MESOS_AUTHENTICATION_ENABLED}
 
     #  (Optional) The Mesos principal used for framework authentication.
     authentication.principal = ${?METRONOME_MESOS_AUTHENTICATION_PRINCIPAL}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -385,6 +385,9 @@ metronome {
   }
 
   mesos {
+    #  (Optional Default: false) Enable framework authentication.
+    authentication = ${?METRONOME_MESOS_AUTHENTICATION}
+
     #  (Optional) The Mesos principal used for framework authentication.
     authentication.principal = ${?METRONOME_MESOS_AUTHENTICATION_PRINCIPAL}
 

--- a/src/main/scala/dcos/metronome/MetronomeConfig.scala
+++ b/src/main/scala/dcos/metronome/MetronomeConfig.scala
@@ -21,7 +21,7 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
   lazy val mesosUser: Option[String] = configuration.getString("metronome.mesos.user").orElse(new SystemProperties().get("user.name"))
   lazy val mesosExecutorDefault: String = configuration.getString("metronome.mesos.executor.default").getOrElse("//cmd")
   lazy val mesosFailoverTimeout: FiniteDuration = configuration.getFiniteDuration("metronome.mesos.failover.timeout").getOrElse(7.days)
-  lazy val mesosAuthentication: Boolean = configuration.getBoolean("metronome.mesos.authentication").getOrElse(false)
+  lazy val mesosAuthentication: Boolean = configuration.getBoolean("metronome.mesos.authentication.enabled").getOrElse(false)
   lazy val mesosAuthenticationPrincipal: Option[String] = configuration.getString("metronome.mesos.authentication.principal")
   lazy val mesosAuthenticationSecretsFile: Option[String] = configuration.getString("metronome.mesos.authentication.secret.file")
 

--- a/src/main/scala/dcos/metronome/MetronomeConfig.scala
+++ b/src/main/scala/dcos/metronome/MetronomeConfig.scala
@@ -21,6 +21,7 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
   lazy val mesosUser: Option[String] = configuration.getString("metronome.mesos.user").orElse(new SystemProperties().get("user.name"))
   lazy val mesosExecutorDefault: String = configuration.getString("metronome.mesos.executor.default").getOrElse("//cmd")
   lazy val mesosFailoverTimeout: FiniteDuration = configuration.getFiniteDuration("metronome.mesos.failover.timeout").getOrElse(7.days)
+  lazy val mesosAuthentication: Boolean = configuration.getBoolean("metronome.mesos.authentication").getOrElse(false)
   lazy val mesosAuthenticationPrincipal: Option[String] = configuration.getString("metronome.mesos.authentication.principal")
   lazy val mesosAuthenticationSecretsFile: Option[String] = configuration.getString("metronome.mesos.authentication.secret.file")
 
@@ -55,7 +56,8 @@ class MetronomeConfig(configuration: Configuration) extends JobsConfig with ApiC
   override lazy val scallopConf: AllConf = {
     val flags = Seq[Option[String]](
       if (httpPort.isEmpty) Some("--disable_http") else None,
-      if (zkCompressionEnabled) Some("--zk_compression") else None
+      if (zkCompressionEnabled) Some("--zk_compression") else None,
+      if (mesosAuthentication) Some("--mesos_authentication") else None
     )
     val options = Map[String, Option[String]](
       "--framework_name" -> Some(frameworkName),


### PR DESCRIPTION
Summary: We updated marathon inside metronome from 1.2.0-RC to 1.3.13. 1.3.0 version of marathon introduced new mesos authentication flag (see https://github.com/mesosphere/marathon/releases/tag/v1.3.0). Without that flag, authentication is not enabled even if principal is provided.
Currently, dcos integration tests enable authentication through env. variables like this https://github.com/mesosphere/dcos-enterprise/blob/master/gen_extra/dcos-config.yaml#L845
I have added new flag to metronome that enables authentication explicitly.
After this patch is merged, the next step is to patch dcos-config.yaml to pass this env. variable that will enable the authentication again.

For more information see this pull request https://github.com/mesosphere/dcos-enterprise/pull/1813

JIRA: MARATHON_EE-1726