### PR TITLE
Release 0.3.1 and prepare for 0.3.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
-# Version 0.3.0
+# Version 0.3.1
 
-Diff [0.2.4-0.3.0](https://github.com/dcos/metronome/compare/v0.2.4...v0.3.0)
+Diff [0.2.4-0.3.1](https://github.com/dcos/metronome/compare/v0.2.4...v0.3.1)
 
 ## Features
 
@@ -18,8 +18,8 @@ Diff [0.2.4-0.3.0](https://github.com/dcos/metronome/compare/v0.2.4...v0.3.0)
 
 ## Download
 
-https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.0/metronome-0.3.0.tgz
-sha: f1a85ee638bc5b31dcd5594da4e84ca3e7a36451
+https://s3.amazonaws.com/downloads.mesosphere.io/metronome/releases/0.3.1/metronome-0.3.1.tgz
+sha: f6fd3d48a889ea19cb13dfd908a82e53c03ffab1
 
 # Version 0.2.4
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1"
+version in ThisBuild := "0.3.2"


### PR DESCRIPTION
There was a bug in 0.3.0 so that version will never be public. I updated the changelog and had the repo ready for working on 0.3.2

JIRA: MARATHON_EE-1726