### PR TITLE
Add taskKillGracePeriod

### DIFF
--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -145,6 +145,10 @@
           "type": "string",
           "description": "The user to use to run the tasks on the agent."
         },
+        "taskKillGracePeriodSeconds" : {
+          "type": "number",
+          "description": "Configures the number of seconds between escalating from SIGTERM to SIGKILL when signalling tasks to terminate. Using this grace period, tasks should perform orderly shut down immediately upon receiving SIGTERM."
+        },
         "restart": {
           "type": "object",
           "additionalProperties": false,

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -1,10 +1,10 @@
 package dcos.metronome.api.v1.controllers
 
 import dcos.metronome.api.v1.models._
-import dcos.metronome.api.{ TestAuthFixture, MockApiComponents, OneAppPerTestWithComponents, UnknownJob }
-import dcos.metronome.model.{ JobId, CronSpec, JobSpec, ScheduleSpec }
+import dcos.metronome.api.{MockApiComponents, OneAppPerTestWithComponents, TestAuthFixture, UnknownJob}
+import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
-import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
+import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.PlaySpec
 import play.api.ApplicationLoader.Context
@@ -24,8 +24,6 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpec1Json)).get
 
       Then("The job is created")
-      println(jobSpec1Json)
-      println(contentAsJson(response))
       status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
       contentAsJson(response) mustBe jobSpec1Json
@@ -296,7 +294,9 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
     }
   }
 
-  def spec(id: String) = JobSpec(JobId(id))
+  import scala.concurrent.duration._
+
+  def spec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds)))
   val CronSpec(cron) = "* * * * *"
   val schedule1 = ScheduleSpec("id1", cron)
   val jobSpec1 = spec("spec1")

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -1,10 +1,10 @@
 package dcos.metronome.api.v1.controllers
 
 import dcos.metronome.api.v1.models._
-import dcos.metronome.api.{MockApiComponents, OneAppPerTestWithComponents, TestAuthFixture, UnknownJob}
+import dcos.metronome.api.{ MockApiComponents, OneAppPerTestWithComponents, TestAuthFixture, UnknownJob }
 import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
-import org.scalatest.{BeforeAndAfter, GivenWhenThen}
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.play.PlaySpec
 import play.api.ApplicationLoader.Context

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -173,6 +173,14 @@ message JobSpec {
       optional int64 activeDeadline = 2;
     }
     optional RestartSpec restart = 13;
+
+    // mesos kill policy https://github.com/apache/mesos/blob/master/include/mesos/mesos.proto#L625
+    // for some reason referred to as taskKillGracePeriod in marathon.
+    // https://github.com/mesosphere/marathon/blob/releases/1.3/src/main/scala/mesosphere/marathon/state/AppDefinition.scala#L79
+    // AND taskKillGracePeriodSeconds
+    // https://github.com/mesosphere/marathon/blob/releases/1.3/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
+    // int64 in mesos and int32 in marathon... going with int64
+    optional int64 taskKillGracePeriodSeconds = 14;
   }
   optional RunSpec run = 6;
 }

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -180,7 +180,7 @@ message JobSpec {
     // AND taskKillGracePeriodSeconds
     // https://github.com/mesosphere/marathon/blob/releases/1.3/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
     // int64 in mesos and int32 in marathon... going with int64
-    optional int64 taskKillGracePeriodSeconds = 14;
+    optional int64 TaskKillGracePeriodSeconds = 14;
   }
   optional RunSpec run = 6;
 }

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -180,7 +180,7 @@ message JobSpec {
     // AND taskKillGracePeriodSeconds
     // https://github.com/mesosphere/marathon/blob/releases/1.3/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
     // int64 in mesos and int32 in marathon... going with int64
-    optional int64 TaskKillGracePeriodSeconds = 14;
+    optional int64 task_kill_grace_period_seconds = 14;
   }
   optional RunSpec run = 6;
 }

--- a/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
@@ -6,19 +6,20 @@ import scala.collection.immutable._
 case class Artifact(uri: String, extract: Boolean = true, executable: Boolean = false, cache: Boolean = false)
 
 case class JobRunSpec(
-  cpus:           Double              = JobRunSpec.DefaultCpus,
-  mem:            Double              = JobRunSpec.DefaultMem,
-  disk:           Double              = JobRunSpec.DefaultDisk,
-  cmd:            Option[String]      = JobRunSpec.DefaultCmd,
-  args:           Option[Seq[String]] = JobRunSpec.DefaultArgs,
-  user:           Option[String]      = JobRunSpec.DefaultUser,
-  env:            Map[String, String] = JobRunSpec.DefaultEnv,
-  placement:      PlacementSpec       = JobRunSpec.DefaultPlacement,
-  artifacts:      Seq[Artifact]       = JobRunSpec.DefaultArtifacts,
-  maxLaunchDelay: Duration            = JobRunSpec.DefaultMaxLaunchDelay,
-  docker:         Option[DockerSpec]  = JobRunSpec.DefaultDocker,
-  volumes:        Seq[Volume]         = JobRunSpec.DefaultVolumes,
-  restart:        RestartSpec         = JobRunSpec.DefaultRestartSpec
+  cpus:                       Double                 = JobRunSpec.DefaultCpus,
+  mem:                        Double                 = JobRunSpec.DefaultMem,
+  disk:                       Double                 = JobRunSpec.DefaultDisk,
+  cmd:                        Option[String]         = JobRunSpec.DefaultCmd,
+  args:                       Option[Seq[String]]    = JobRunSpec.DefaultArgs,
+  user:                       Option[String]         = JobRunSpec.DefaultUser,
+  env:                        Map[String, String]    = JobRunSpec.DefaultEnv,
+  placement:                  PlacementSpec          = JobRunSpec.DefaultPlacement,
+  artifacts:                  Seq[Artifact]          = JobRunSpec.DefaultArtifacts,
+  maxLaunchDelay:             Duration               = JobRunSpec.DefaultMaxLaunchDelay,
+  docker:                     Option[DockerSpec]     = JobRunSpec.DefaultDocker,
+  volumes:                    Seq[Volume]            = JobRunSpec.DefaultVolumes,
+  restart:                    RestartSpec            = JobRunSpec.DefaultRestartSpec,
+  taskKillGracePeriodSeconds: Option[FiniteDuration] = JobRunSpec.DefaultTaskKillGracePeriodSeconds
 )
 
 object JobRunSpec {
@@ -35,5 +36,6 @@ object JobRunSpec {
   val DefaultDocker = None
   val DefaultVolumes = Seq.empty[Volume]
   val DefaultRestartSpec = RestartSpec()
+  val DefaultTaskKillGracePeriodSeconds = None
 }
 

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -136,6 +136,7 @@ object RunSpecConversions {
       runSpec.args.foreach { args => builder.addAllArguments(args.asJava) }
       runSpec.user.foreach(builder.setUser)
       runSpec.docker.foreach { docker => builder.setDocker(docker.toProto) }
+      runSpec.taskKillGracePeriodSeconds.foreach { killGracePeriod => builder.setTaskKillGracePeriodSeconds(killGracePeriod.toMillis) }
 
       builder.build()
     }

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -136,7 +136,7 @@ object RunSpecConversions {
       runSpec.args.foreach { args => builder.addAllArguments(args.asJava) }
       runSpec.user.foreach(builder.setUser)
       runSpec.docker.foreach { docker => builder.setDocker(docker.toProto) }
-      runSpec.taskKillGracePeriodSeconds.foreach { killGracePeriod => builder.setTaskKillGracePeriodSeconds(killGracePeriod.toMillis) }
+      runSpec.taskKillGracePeriodSeconds.foreach { killGracePeriod => builder.setTaskKillGracePeriodSeconds(killGracePeriod.toSeconds) }
 
       builder.build()
     }
@@ -150,6 +150,7 @@ object RunSpecConversions {
       val args = if (runSpec.getArgumentsCount == 0) None else Some(runSpec.getArgumentsList.asScala.toList)
       val user = if (runSpec.hasUser) Some(runSpec.getUser) else None
       val docker = if (runSpec.hasDocker) Some(runSpec.getDocker.toModel) else None
+      val taskKillGracePeriodSeconds = if (runSpec.hasTaskKillGracePeriodSeconds) Some(Duration(runSpec.getTaskKillGracePeriodSeconds, SECONDS)) else None
 
       JobRunSpec(
         cpus = runSpec.getCpus,
@@ -164,7 +165,8 @@ object RunSpecConversions {
         cmd = cmd,
         args = args,
         user = user,
-        docker = docker
+        docker = docker,
+        taskKillGracePeriodSeconds = taskKillGracePeriodSeconds
       )
     }
   }

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -105,7 +105,7 @@ object MarathonImplicits {
         container = jobSpec.toContainer,
         healthChecks = Set.empty[HealthCheck],
         readinessChecks = Seq.empty[ReadinessCheck],
-        taskKillGracePeriod = None,
+        taskKillGracePeriod = jobSpec.run.taskKillGracePeriodSeconds,
         dependencies = Set.empty[PathId],
         upgradeStrategy = UpgradeStrategy(minimumHealthCapacity = 0.0, maximumOverCapacity = 1.0),
         labels = jobSpec.labels,

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -44,7 +44,8 @@ class JobSpecMarshallerTest extends FunSuite with Matchers {
       volumes = Seq(
         Volume(containerPath = "/var/log", hostPath = "/sandbox/task1/var/log", mode = Mode.RW)
       ),
-      restart = RestartSpec(policy = RestartPolicy.OnFailure, activeDeadline = Some(15.days))
+      restart = RestartSpec(policy = RestartPolicy.OnFailure, activeDeadline = Some(15.days)),
+      taskKillGracePeriodSeconds = Some(10 seconds)
     )
 
     val jobSpec = JobSpec(


### PR DESCRIPTION
Added ability to send taskKillGracePeriodSeconds to marathon libs from metronome.
Changed the name to include suffix `Seconds` which is consistent with parts of marathon:)


https://jira.mesosphere.com/browse/METRONOME-151

Jira:  METRONOME-151