### PR TITLE
Making play.crypto.secret Updatable

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -68,6 +68,7 @@ akka {
 # The secret key is used to sign Play's session cookie.
 # This must be changed for production, but we don't recommend you change it in this file.
 play.crypto.secret = "fd86c43eca3f44e4bfeaaf7e5a3de598c6063d7ae0c2e11d1fcc3258fe136bc57ec"
+play.crypto.secret = ${?METRONOME_PLAY_CRYPTO_SECRET}
 
 ## Modules
 # https://www.playframework.com/documentation/latest/Modules


### PR DESCRIPTION
The secret is the same secret for all distros of metronome and DCOS.  This defeats the purpose of the secret.   

https://jira.mesosphere.com/browse/METRONOME-5

JIRA:  METRONOME-5