### PR TITLE
HTTP 404 error with a proper message

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
+++ b/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
@@ -37,5 +37,5 @@ class ErrorHandler extends HttpErrorHandler {
 }
 
 object ErrorHandler {
-  val noRouteHandlerMessage = "Unsupported route, no handler found."
+  val noRouteHandlerMessage = "Unknown route."
 }

--- a/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
+++ b/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
@@ -15,7 +15,8 @@ class ErrorHandler extends HttpErrorHandler {
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = {
     log.debug(s"Client Error on path ${request.path}. Message: $message Status: $statusCode")
-    val json = Json.obj("message" -> escape(message), "requestPath" -> escape(request.path))
+    val outputMessage = if (statusCode == NOT_FOUND) { ErrorHandler.noRouteHandlerMessage } else { message }
+    val json = Json.obj("message" -> escape(outputMessage), "requestPath" -> escape(request.path))
     Future.successful(Results.Status(statusCode)(json))
   }
 
@@ -33,4 +34,8 @@ class ErrorHandler extends HttpErrorHandler {
     * To prevent possible interpretation of the message: all strings get HTML escaped
     */
   private def escape(msg: String): String = HtmlFormat.escape(msg).body
+}
+
+object ErrorHandler {
+  val noRouteHandlerMessage = "Unsupported route, no handler found."
 }

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -1,8 +1,8 @@
 package dcos.metronome.api.v1.controllers
 
 import dcos.metronome.api.v1.models._
-import dcos.metronome.api.{ TestAuthFixture, MockApiComponents, OneAppPerTestWithComponents, UnknownJob }
-import dcos.metronome.model.{ JobId, CronSpec, JobSpec, ScheduleSpec }
+import dcos.metronome.api._
+import dcos.metronome.model.{ CronSpec, JobId, JobSpec, ScheduleSpec }
 import mesosphere.marathon.core.plugin.PluginManager
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
 import org.scalatest.concurrent.ScalaFutures
@@ -169,6 +169,17 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
 
       Then("a forbidden response is send")
       status(unauthorized) mustBe FORBIDDEN
+    }
+  }
+
+  "POST /jobs/{id}" should {
+    "end as 404 invalid request with error message" in {
+      Given("An invalid request")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs/${jobSpec1.id}").withJsonBody(jobSpec1Json)).get
+
+      Then("404 response with a message is returned")
+      status(response) mustBe NOT_FOUND
+      contentAsJson(response) \ "message" mustBe JsDefined(JsString(ErrorHandler.noRouteHandlerMessage))
     }
   }
 

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -1,7 +1,7 @@
 package dcos.metronome.api.v1.controllers
 
 import dcos.metronome.api.v1.models._
-import dcos.metronome.api._
+import dcos.metronome.api.{ MockApiComponents, OneAppPerTestWithComponents, TestAuthFixture, UnknownJob, ErrorHandler }
 import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
 import org.scalatest.{BeforeAndAfter, GivenWhenThen}


### PR DESCRIPTION
Summary: When no route handler is found for a given route, we currently return HTTP 404 with no message. This PR adds a message.

This is a recommended way to do so, see GlobalSettings.onHandlerNotFound here https://www.playframework.com/documentation/2.6.x/GlobalSettings

JIRA: METRONOME-91