### PR TITLE
Authorization for a Run Instance MUST be against JobSpec

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
@@ -31,7 +31,7 @@ class JobRunController(
   def getJobRun(id: JobId, runId: String) = AuthorizedAction.async { implicit request =>
     async {
       await(jobRunService.getJobRun(JobRunId(id, runId))) match {
-        case Some(run) => request.authorized(ViewRunSpec, run, Ok(run))
+        case Some(run) => request.authorized(ViewRunSpec, run.jobRun.jobSpec, Ok(run))
         case None      => NotFound(UnknownJobRun(id, runId))
       }
     }

--- a/api/src/test/scala/dcos/metronome/api/TestAuthFixture.scala
+++ b/api/src/test/scala/dcos/metronome/api/TestAuthFixture.scala
@@ -34,7 +34,7 @@ class TestAuthFixture extends Mockito with Status {
       action:    AuthorizedAction[Resource],
       resource:  Resource
     ): Boolean = {
-      authorized && authFn(resource)
+      authFn(resource) && authorized
     }
   }
 


### PR DESCRIPTION
Authorization for a Run Instance MUST be against JobSpec

Summary:
As outlined in https://jira.mesosphere.com/browse/METRONOME-185
Job runs based on authorization were returned in the map of jobs returned by `/v1/jobs/{jobid}/runs` however they were not authorized against the endpoint `/v1/jobs/{jobid}/runs/{runid}`.     This was exasperated by the fact that much of the SI testing is against the superuser and the integration tests bypass real auth by enabling the `auth.authorized = false`.   There was no test against the ViewRunSpec.   This JIRA: https://jira.mesosphere.com/browse/METRONOME-186 will provide a PR for an SI test to make sure a regression doesn't happen.

This solution has been tested in a full EE DCOS 1.11 Permissive environment.

JIRA issues:  METRONOME-185
