### PR TITLE
Do not compile protoc on every build

### DIFF
--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -10,9 +10,8 @@ fi
 if [ ! -d "$HOME/protoc" ]; then
   curl -L -o protoc-3.3.0.zip $download_url
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
-  mv -v ./protoc-3.3.0 ~/protoc
+  mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
-  export PATH=~/protoc/bin:$PATH
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -14,7 +14,6 @@ if [ ! -d "$HOME/protobuf" ]; then
   rm protoc-3.3.0.zip
   export PATH=~/protobuf/bin:$PATH
   ls -l ~/protobuf/bin
-  ~/protobuf/bin/protoc
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -7,7 +7,7 @@ echo $unamestr
 if [ "$unamestr" == 'Darwin' ]; then
    download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-osx-x86_64.zip'
 fi
-if [ ! -d "$HOME/protoc" ]; then
+if [ ! -d "$HOME/protobuf" ]; then
   curl -L -o protoc-3.3.0.zip $download_url
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
   mv -v ./protoc-3.3.0 ~/protobuf

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -13,7 +13,7 @@ if [ ! -d "$HOME/protobuf" ]; then
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
   export PATH=~/protobuf/bin:$PATH
-  protoc
+  ~/protobuf/bin/protoc
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -12,8 +12,6 @@ if [ ! -d "$HOME/protobuf" ]; then
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
-  export PATH=~/protobuf/bin:$PATH
-  ls -l ~/protobuf/bin
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -4,7 +4,7 @@ set -e
 download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_32.zip'
 unamestr=`uname`
 echo $unamestr
-if [[ "$unamestr" == 'Darwin' ]]; then
+if [ "$unamestr" == 'Darwin' ]; then
    download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-osx-x86_64.zip'
 fi
 if [ ! -d "$HOME/protoc" ]; then

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -12,6 +12,7 @@ if [ ! -d "$HOME/protoc" ]; then
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
+  ls ~/protobuf/bin/
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -13,6 +13,7 @@ if [ ! -d "$HOME/protobuf" ]; then
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
   export PATH=~/protobuf/bin:$PATH
+  ls -l ~/protobuf/bin
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 # check to see if protobuf folder is empty
-download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_32.zip'
+download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip'
 unamestr=`uname`
 echo $unamestr
 if [ "$unamestr" == 'Darwin' ]; then
@@ -14,8 +14,7 @@ if [ ! -d "$HOME/protobuf" ]; then
   rm protoc-3.3.0.zip
   export PATH=~/protobuf/bin:$PATH
   ls -l ~/protobuf/bin
+  ~/protobuf/bin/protoc
 else
   echo "Using already installed protoc."
 fi
-
-~/protobuf/bin/protoc

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -1,17 +1,20 @@
 #!/bin/sh
+
+VERSION="${1:-3.3.0}"
+
 set -e
 # check to see if protobuf folder is empty
-download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_64.zip'
-unamestr=`uname`
-echo $unamestr
-if [ "$unamestr" == 'Darwin' ]; then
-   download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-osx-x86_64.zip'
+DOWNLOAD_URL="https://github.com/google/protobuf/releases/download/v$VERSION/protoc-$VERSION-linux-x86_64.zip"
+PLATFORM=`uname`
+echo $PLATFORM
+if [ "$PLATFORM" == 'Darwin' ]; then
+   DOWNLOAD_URL="https://github.com/google/protobuf/releases/download/v$VERSION/protoc-$VERSION-osx-x86_64.zip"
 fi
 if [ ! -d "$HOME/protobuf" ]; then
-  curl -L -o protoc-3.3.0.zip $download_url
-  unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
-  mv -v ./protoc-3.3.0 ~/protobuf
-  rm protoc-3.3.0.zip
+  curl -L -o protoc.zip ${DOWNLOAD_URL}
+  unzip -d protoc -a protoc.zip
+  mv -v ./protoc ~/protobuf
+  rm protoc.zip
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -13,7 +13,8 @@ if [ ! -d "$HOME/protobuf" ]; then
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
   export PATH=~/protobuf/bin:$PATH
-  ~/protobuf/bin/protoc
 else
   echo "Using already installed protoc."
 fi
+
+~/protobuf/bin/protoc

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -12,7 +12,8 @@ if [ ! -d "$HOME/protobuf" ]; then
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
   mv -v ./protoc-3.3.0 ~/protobuf
   rm protoc-3.3.0.zip
-  ls ~/protobuf/bin/
+  export PATH=~/protobuf/bin:$PATH
+  protoc
 else
   echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -1,10 +1,17 @@
 #!/bin/sh
 set -e
 # check to see if protobuf folder is empty
-if [ ! -d "$HOME/protobuf/lib" ]; then
-  curl -L -o protobuf-3.3.0.tar.gz https://github.com/google/protobuf/archive/v3.3.0.tar.gz
-  tar -xzvf protobuf-3.3.0.tar.gz
-  cd protobuf-3.3.0 && ./autogen.sh && ./configure --prefix=$HOME/protobuf && make && make install
+download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-linux-x86_32.zip'
+unamestr=`uname`
+echo $unamestr
+if [[ "$unamestr" == 'Darwin' ]]; then
+   download_url='https://github.com/google/protobuf/releases/download/v3.3.0/protoc-3.3.0-osx-x86_64.zip'
+fi
+if [ ! -d "$HOME/protoc" ]; then
+  curl -L -o protoc-3.3.0.zip $download_url
+  unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
+  mv -v ./protoc-3.3.0 ~/protoc
+  rm protoc-3.3.0.zip
 else
-  echo "Using cached protobuf."
+  echo "Using already installed protoc."
 fi

--- a/bin/install-protobuf.sh
+++ b/bin/install-protobuf.sh
@@ -12,6 +12,7 @@ if [ ! -d "$HOME/protoc" ]; then
   unzip -d protoc-3.3.0 -a protoc-3.3.0.zip
   mv -v ./protoc-3.3.0 ~/protoc
   rm protoc-3.3.0.zip
+  export PATH=~/protoc/bin:$PATH
 else
   echo "Using already installed protoc."
 fi

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,8 +16,7 @@ import scalariform.formatter.preferences._
 object Build extends sbt.Build {
 
   val pbSettings = PB.projectSettings ++ Seq(
-    (version in ProtobufConfig) := "3.3.0",
-    PB.Keys.protobufProtoc := "/root/protobuf/bin/protoc"
+    (version in ProtobufConfig) := "3.3.0"
   )
   lazy val metronome = Project(
     id = "metronome",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,8 @@ import scalariform.formatter.preferences._
 object Build extends sbt.Build {
 
   val pbSettings = PB.projectSettings ++ Seq(
-    (version in ProtobufConfig) := "3.3.0"
+    (version in ProtobufConfig) := "3.3.0",
+    PB.Keys.protobufProtoc := "/root/protobuf/bin/protoc"
   )
   lazy val metronome = Project(
     id = "metronome",


### PR DESCRIPTION
Summary:
I don't think we need to compile protobuf from sources on every jenkins run. Google publishes already precompiled binaries for all platforms.

This PR alters the install script in a way that it takes advantage of these precompiled binaries.

JIRA issues: METRONOME-188