### PR TITLE
Implement start deadline

### DIFF
--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -68,6 +68,7 @@ message JobRun {
     optional Status status = 4;
   }
   repeated JobRunTask tasks = 6;
+  optional int64 starting_deadline_seconds = 7;
 }
 
 message JobSpec {

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
@@ -28,10 +28,10 @@ class JobRunModule(
 
   import com.softwaremill.macwire._
 
-  private[this] def executorFactory(jobRun: JobRun, startingDeadline: Option[Duration], promise: Promise[JobResult]): Props = {
+  private[this] def executorFactory(jobRun: JobRun, promise: Promise[JobResult]): Props = {
     val persistenceActorFactory = (id: JobRunId, context: ActorContext) =>
       context.actorOf(JobRunPersistenceActor.props(id, jobRunRepository, behavior))
-    JobRunExecutorActor.props(jobRun, startingDeadline, promise, persistenceActorFactory,
+    JobRunExecutorActor.props(jobRun, promise, persistenceActorFactory,
       launchQueue, taskTracker, driverHolder, clock, behavior)
   }
 

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
@@ -32,7 +32,7 @@ class JobRunModule(
     val persistenceActorFactory = (id: JobRunId, context: ActorContext) =>
       context.actorOf(JobRunPersistenceActor.props(id, jobRunRepository, behavior))
     JobRunExecutorActor.props(jobRun, promise, persistenceActorFactory,
-      launchQueue, taskTracker, driverHolder, clock, behavior)
+      launchQueue, taskTracker, driverHolder, clock, behavior)(actorSystem.scheduler)
   }
 
   val jobRunServiceActor = leadershipModule.startWhenLeader(

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
@@ -1,10 +1,10 @@
 package dcos.metronome
 package jobrun
 
-import akka.actor.{ ActorContext, ActorSystem, Props }
+import akka.actor.{ActorContext, ActorSystem, Props}
 import dcos.metronome.behavior.Behavior
-import dcos.metronome.jobrun.impl.{ JobRunExecutorActor, JobRunPersistenceActor, JobRunServiceActor, JobRunServiceDelegate }
-import dcos.metronome.model.{ JobResult, JobRun, JobRunId }
+import dcos.metronome.jobrun.impl.{JobRunExecutorActor, JobRunPersistenceActor, JobRunServiceActor, JobRunServiceDelegate}
+import dcos.metronome.model.{JobResult, JobRun, JobRunId}
 import dcos.metronome.repository.Repository
 import dcos.metronome.utils.time.Clock
 import mesosphere.marathon.MarathonSchedulerDriverHolder
@@ -13,6 +13,7 @@ import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.leadership.LeadershipModule
 
 import scala.concurrent.Promise
+import scala.concurrent.duration.Duration
 
 class JobRunModule(
   config:           JobRunConfig,
@@ -27,10 +28,10 @@ class JobRunModule(
 
   import com.softwaremill.macwire._
 
-  private[this] def executorFactory(jobRun: JobRun, promise: Promise[JobResult]): Props = {
+  private[this] def executorFactory(jobRun: JobRun, startingDeadline: Option[Duration], promise: Promise[JobResult]): Props = {
     val persistenceActorFactory = (id: JobRunId, context: ActorContext) =>
       context.actorOf(JobRunPersistenceActor.props(id, jobRunRepository, behavior))
-    JobRunExecutorActor.props(jobRun, promise, persistenceActorFactory,
+    JobRunExecutorActor.props(jobRun, startingDeadline, promise, persistenceActorFactory,
       launchQueue, taskTracker, driverHolder, clock, behavior)
   }
 

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
@@ -1,10 +1,10 @@
 package dcos.metronome
 package jobrun
 
-import akka.actor.{ActorContext, ActorSystem, Props}
+import akka.actor.{ ActorContext, ActorSystem, Props }
 import dcos.metronome.behavior.Behavior
-import dcos.metronome.jobrun.impl.{JobRunExecutorActor, JobRunPersistenceActor, JobRunServiceActor, JobRunServiceDelegate}
-import dcos.metronome.model.{JobResult, JobRun, JobRunId}
+import dcos.metronome.jobrun.impl.{ JobRunExecutorActor, JobRunPersistenceActor, JobRunServiceActor, JobRunServiceDelegate }
+import dcos.metronome.model.{ JobResult, JobRun, JobRunId }
 import dcos.metronome.repository.Repository
 import dcos.metronome.utils.time.Clock
 import mesosphere.marathon.MarathonSchedulerDriverHolder

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
@@ -1,9 +1,10 @@
 package dcos.metronome
 package jobrun
 
-import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
+import dcos.metronome.model.{JobId, JobRun, JobRunId, JobSpec}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 /**
   * The JobRunService can be used to start JobRuns, kill started JobRuns and list active JobRuns.
@@ -40,7 +41,7 @@ trait JobRunService {
     * @param jobSpec the specification to run.
     * @return the started job run
     */
-  def startJobRun(jobSpec: JobSpec): Future[StartedJobRun]
+  def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun]
 
   /**
     * Kill a given job run by the given job run id.

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
@@ -1,7 +1,7 @@
 package dcos.metronome
 package jobrun
 
-import dcos.metronome.model.{JobId, JobRun, JobRunId, JobSpec}
+import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -45,6 +45,8 @@ class JobRunExecutorActor(
   val runSpecId = jobRun.id.toPathId
 
   override def preStart(): Unit = {
+    scheduleStartingDeadlineTimeout()
+    
     jobRun.status match {
       case JobRunStatus.Initial => becomeCreating()
 

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -1,7 +1,7 @@
 package dcos.metronome
 package jobrun.impl
 
-import akka.actor.{ Actor, ActorContext, ActorLogging, ActorRef, Cancellable, Props, Stash }
+import akka.actor.{ Actor, ActorContext, ActorLogging, ActorRef, Cancellable, Props, Scheduler, Stash }
 import dcos.metronome.{ JobRunFailed, UnexpectedTaskState }
 import dcos.metronome.behavior.{ ActorBehavior, Behavior }
 import dcos.metronome.eventbus.TaskStateChangedEvent
@@ -33,7 +33,7 @@ class JobRunExecutorActor(
     driverHolder:               MarathonSchedulerDriverHolder,
     clock:                      Clock,
     val behavior:               Behavior
-) extends Actor with Stash with ActorLogging with ActorBehavior {
+)(implicit scheduler: Scheduler) extends Actor with Stash with ActorLogging with ActorBehavior {
   import JobRunExecutorActor._
   import JobRunPersistenceActor._
   import TaskStates._
@@ -380,7 +380,7 @@ object JobRunExecutorActor {
       launchQueue, taskTracker, driverHolder, clock, behavior))
 =======
     behavior:                   Behavior
-  ): Props = Props(
+  )(implicit scheduler: Scheduler): Props = Props(
     new JobRunExecutorActor(run, promise, persistenceActorRefFactory,
       launchQueue, taskTracker, driverHolder, clock, behavior)
   )

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -25,15 +25,14 @@ import scala.concurrent.duration.{ Duration, FiniteDuration }
   * @param run the related job run object.
   */
 class JobRunExecutorActor(
-    run:                        JobRun,
-    promise:                    Promise[JobResult],
-    persistenceActorRefFactory: (JobRunId, ActorContext) => ActorRef,
-    launchQueue:                LaunchQueue,
-    taskTracker:                TaskTracker,
-    driverHolder:               MarathonSchedulerDriverHolder,
-    clock:                      Clock,
-    val behavior:               Behavior
-)(implicit scheduler: Scheduler) extends Actor with Stash with ActorLogging with ActorBehavior {
+  run:                        JobRun,
+  promise:                    Promise[JobResult],
+  persistenceActorRefFactory: (JobRunId, ActorContext) => ActorRef,
+  launchQueue:                LaunchQueue,
+  taskTracker:                TaskTracker,
+  driverHolder:               MarathonSchedulerDriverHolder,
+  clock:                      Clock,
+  val behavior:               Behavior)(implicit scheduler: Scheduler) extends Actor with Stash with ActorLogging with ActorBehavior {
   import JobRunExecutorActor._
   import JobRunPersistenceActor._
   import TaskStates._
@@ -383,17 +382,9 @@ object JobRunExecutorActor {
     taskTracker:                TaskTracker,
     driverHolder:               MarathonSchedulerDriverHolder,
     clock:                      Clock,
-<<<<<<< HEAD
-    behavior:                   Behavior): Props = Props(
+    behavior:                   Behavior)(implicit scheduler: Scheduler): Props = Props(
     new JobRunExecutorActor(run, promise, persistenceActorRefFactory,
       launchQueue, taskTracker, driverHolder, clock, behavior))
-=======
-    behavior:                   Behavior
-  )(implicit scheduler: Scheduler): Props = Props(
-    new JobRunExecutorActor(run, promise, persistenceActorRefFactory,
-      launchQueue, taskTracker, driverHolder, clock, behavior)
-  )
->>>>>>> Implement start deadline METRONOME-191
 }
 
 object TaskStates {

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -3,11 +3,11 @@ package jobrun.impl
 
 import akka.actor._
 import dcos.metronome.JobRunDoesNotExist
-import dcos.metronome.behavior.{ActorBehavior, Behavior}
+import dcos.metronome.behavior.{ ActorBehavior, Behavior }
 import dcos.metronome.eventbus.TaskStateChangedEvent
 import dcos.metronome.jobrun.StartedJobRun
 import dcos.metronome.model._
-import dcos.metronome.repository.{LoadContentOnStartup, Repository}
+import dcos.metronome.repository.{ LoadContentOnStartup, Repository }
 import dcos.metronome.utils.time.Clock
 
 import scala.collection.concurrent.TrieMap
@@ -43,22 +43,22 @@ class JobRunServiceActor(
 
   override def receive: Receive = around {
     // api messages
-    case ListRuns(filter)              => sender() ! allJobRuns.values.filter(startedJobRun => filter(startedJobRun.jobRun))
-    case GetJobRun(id)                 => sender() ! allJobRuns.get(id)
-    case GetActiveJobRuns(specId)      => sender() ! runsForJob(specId)
-    case KillJobRun(id)                => killJobRun(id)
+    case ListRuns(filter)                      => sender() ! allJobRuns.values.filter(startedJobRun => filter(startedJobRun.jobRun))
+    case GetJobRun(id)                         => sender() ! allJobRuns.get(id)
+    case GetActiveJobRuns(specId)              => sender() ! runsForJob(specId)
+    case KillJobRun(id)                        => killJobRun(id)
 
     // trigger messages
-    case TriggerJobRun(spec, startingDeadline)           => triggerJobRun(spec, startingDeadline)
+    case TriggerJobRun(spec, startingDeadline) => triggerJobRun(spec, startingDeadline)
 
     // executor messages
-    case JobRunUpdate(started)         => updateJobRun(started)
-    case Finished(result)              => jobRunFinished(result)
-    case Aborted(result)               => jobRunFailed(result)
-    case Failed(result)                => jobRunFailed(result)
+    case JobRunUpdate(started)                 => updateJobRun(started)
+    case Finished(result)                      => jobRunFinished(result)
+    case Aborted(result)                       => jobRunFailed(result)
+    case Failed(result)                        => jobRunFailed(result)
 
     //event stream events
-    case update: TaskStateChangedEvent => forwardStatusUpdate(update)
+    case update: TaskStateChangedEvent         => forwardStatusUpdate(update)
   }
 
   def runsForJob(jobId: JobId): Iterable[StartedJobRun] = allJobRuns.values.filter(_.jobRun.id.jobId == jobId)

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -18,11 +18,10 @@ import scala.concurrent.duration.Duration
   * Knows and manages all active JobRunExecutors.
   */
 class JobRunServiceActor(
-    clock:           Clock,
-    executorFactory: (JobRun, Promise[JobResult]) => Props,
-    val repo:        Repository[JobRunId, JobRun], //TODO: remove the repo
-    val behavior:    Behavior
-) extends Actor with LoadContentOnStartup[JobRunId, JobRun] with Stash with ActorBehavior {
+  clock:           Clock,
+  executorFactory: (JobRun, Promise[JobResult]) => Props,
+  val repo:        Repository[JobRunId, JobRun], //TODO: remove the repo
+  val behavior:    Behavior) extends Actor with LoadContentOnStartup[JobRunId, JobRun] with Stash with ActorBehavior {
 
   import JobRunExecutorActor._
   import JobRunServiceActor._

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
@@ -4,8 +4,8 @@ package jobrun.impl
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import dcos.metronome.jobrun.{JobRunConfig, JobRunService, StartedJobRun}
-import dcos.metronome.model.{JobId, JobRun, JobRunId, JobSpec}
+import dcos.metronome.jobrun.{ JobRunConfig, JobRunService, StartedJobRun }
+import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
@@ -4,10 +4,11 @@ package jobrun.impl
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
-import dcos.metronome.jobrun.{ JobRunConfig, JobRunService, StartedJobRun }
-import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
+import dcos.metronome.jobrun.{JobRunConfig, JobRunService, StartedJobRun}
+import dcos.metronome.model.{JobId, JobRun, JobRunId, JobSpec}
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 private[jobrun] class JobRunServiceDelegate(
   config:   JobRunConfig,
@@ -32,7 +33,7 @@ private[jobrun] class JobRunServiceDelegate(
     actorRef.ask(GetActiveJobRuns(jobId)).mapTo[Iterable[StartedJobRun]]
   }
 
-  override def startJobRun(jobSpec: JobSpec): Future[StartedJobRun] = {
-    actorRef.ask(TriggerJobRun(jobSpec)).mapTo[StartedJobRun]
+  override def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
+    actorRef.ask(TriggerJobRun(jobSpec, startingDeadline)).mapTo[StartedJobRun]
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
@@ -2,11 +2,11 @@ package dcos.metronome
 package jobspec.impl
 
 import akka.actor._
-import dcos.metronome.behavior.{ ActorBehavior, Behavior }
+import dcos.metronome.behavior.{ActorBehavior, Behavior}
 import dcos.metronome.jobrun.JobRunService
-import dcos.metronome.model.JobSpec
+import dcos.metronome.model.{JobSpec, ScheduleSpec}
 import dcos.metronome.utils.time.Clock
-import org.joda.time.{ DateTime, Seconds }
+import org.joda.time.{DateTime, Seconds}
 
 import scala.concurrent.duration._
 
@@ -36,7 +36,7 @@ class JobSpecSchedulerActor(
   }
 
   override def receive: Receive = around {
-    case StartJob               => runJob()
+    case StartJob(schedule)               => runJob(schedule)
     case UpdateJobSpec(newSpec) => updateSpec(newSpec)
   }
 
@@ -47,9 +47,9 @@ class JobSpecSchedulerActor(
     scheduleNextRun()
   }
 
-  def runJob(): Unit = {
+  def runJob(schedule: ScheduleSpec): Unit = {
     log.info(s"Start next run of job ${spec.id}, which was scheduled for $scheduledAt")
-    runService.startJobRun(spec)
+    runService.startJobRun(spec, Some(schedule.startingDeadline))
     scheduleNextRun()
   }
 
@@ -64,7 +64,7 @@ class JobSpecSchedulerActor(
       scheduledAt = Some(nextTime)
       // 60 secs is the smallest unit of reschedule time for cron
       val in = Seconds.secondsBetween(now, nextTime).getSeconds.seconds.max(60.seconds)
-      nextSchedule = Some(context.system.scheduler.scheduleOnce(in, self, StartJob))
+      nextSchedule = Some(context.system.scheduler.scheduleOnce(in, self, StartJob(schedule)))
       log.info(s"Spec ${spec.id}: next run is scheduled for: $nextTime (in $in)")
     }
   }
@@ -78,7 +78,7 @@ class JobSpecSchedulerActor(
 
 object JobSpecSchedulerActor {
 
-  case object StartJob
+  case class StartJob(schedule: ScheduleSpec)
   case class UpdateJobSpec(newSpec: JobSpec)
 
   def props(spec: JobSpec, clock: Clock, runService: JobRunService, behavior: Behavior): Props = {

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
@@ -2,11 +2,11 @@ package dcos.metronome
 package jobspec.impl
 
 import akka.actor._
-import dcos.metronome.behavior.{ActorBehavior, Behavior}
+import dcos.metronome.behavior.{ ActorBehavior, Behavior }
 import dcos.metronome.jobrun.JobRunService
-import dcos.metronome.model.{JobSpec, ScheduleSpec}
+import dcos.metronome.model.{ JobSpec, ScheduleSpec }
 import dcos.metronome.utils.time.Clock
-import org.joda.time.{DateTime, Seconds}
+import org.joda.time.{ DateTime, Seconds }
 
 import scala.concurrent.duration._
 
@@ -36,7 +36,7 @@ class JobSpecSchedulerActor(
   }
 
   override def receive: Receive = around {
-    case StartJob(schedule)               => runJob(schedule)
+    case StartJob(schedule)     => runJob(schedule)
     case UpdateJobSpec(newSpec) => updateSpec(newSpec)
   }
 

--- a/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
@@ -15,8 +15,7 @@ case class JobRun(
   createdAt:        DateTime,
   completedAt:      Option[DateTime],
   startingDeadline: Option[Duration],
-  tasks:            Map[Task.Id, JobRunTask]
-)
+  tasks:            Map[Task.Id, JobRunTask])
 
 case class JobRunTask(
   id:          Task.Id,

--- a/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
@@ -6,13 +6,17 @@ import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.LaunchedEphemeral
 import org.joda.time.DateTime
 
+import scala.concurrent.duration.Duration
+
 case class JobRun(
-  id:          JobRunId,
-  jobSpec:     JobSpec,
-  status:      JobRunStatus,
-  createdAt:   DateTime,
-  completedAt: Option[DateTime],
-  tasks:       Map[Task.Id, JobRunTask])
+  id:               JobRunId,
+  jobSpec:          JobSpec,
+  status:           JobRunStatus,
+  createdAt:        DateTime,
+  completedAt:      Option[DateTime],
+  startingDeadline: Option[Duration],
+  tasks:            Map[Task.Id, JobRunTask]
+)
 
 case class JobRunTask(
   id:          Task.Id,

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshaller.scala
@@ -94,11 +94,10 @@ object JobRunConversions {
         createdAt = new DateTime(proto.getCreatedAt, DateTimeZone.UTC),
         completedAt = if (proto.hasFinishedAt) Some(new DateTime(proto.getFinishedAt, DateTimeZone.UTC)) else None,
         startingDeadline = if (proto.hasStartingDeadlineSeconds)
-        Some(Duration(proto.getStartingDeadlineSeconds, TimeUnit.SECONDS))
-      else
-        None,
-        tasks = proto.getTasksList.asScala.map(_.toModel).map(task => task.id -> task).toMap
-      )
+          Some(Duration(proto.getStartingDeadlineSeconds, TimeUnit.SECONDS))
+        else
+          None,
+        tasks = proto.getTasksList.asScala.map(_.toModel).map(task => task.id -> task).toMap)
     }
   }
 

--- a/jobs/src/main/scala/dcos/metronome/utils/time/Clock.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/time/Clock.scala
@@ -21,5 +21,8 @@ class FixedClock(var _now: DateTime) extends Clock {
 
   override def now(): DateTime = _now
 
-  def +=(duration: FiniteDuration): Unit = _now = _now.plusMillis(duration.toMillis.toInt)
+  def +=(duration: FiniteDuration): Unit = {
+    _now = _now.plusMillis(duration.toMillis.toInt)
+    subscribers.foreach(f => f())
+  }
 }

--- a/jobs/src/main/scala/dcos/metronome/utils/time/Clock.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/time/Clock.scala
@@ -14,6 +14,11 @@ class SystemClock(dateTimeZone: DateTimeZone = DateTimeZone.UTC) extends Clock {
 }
 
 class FixedClock(var _now: DateTime) extends Clock {
+  private[this] var subscribers: List[() => Unit] = Nil
+  def onChange(fn: () => Unit): Unit = synchronized {
+    subscribers = fn :: subscribers
+  }
+
   override def now(): DateTime = _now
 
   def +=(duration: FiniteDuration): Unit = _now = _now.plusMillis(duration.toMillis.toInt)

--- a/jobs/src/test/scala/dcos/metronome/SimulatedScheduler.scala
+++ b/jobs/src/test/scala/dcos/metronome/SimulatedScheduler.scala
@@ -1,0 +1,82 @@
+package dcos.metronome
+
+import akka.actor.{ Cancellable, Scheduler }
+import java.util.concurrent.atomic.AtomicLong
+
+import dcos.metronome.utils.time.FixedClock
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Simulates a scheduler using a FixedClock
+  *
+  * Does not use a separate thread for scheduling; however, scheduled tasks are executed according to their provided
+  * ExecutionContext. If using a same-thread execution context, then the task will be executed by the thread that
+  * advances the clock.
+  *
+  * If scheduler checks if tasks need to be run each time the clock is advanced. If a repeating task is scheduled to
+  * happen every 10 seconds, and the clock is advanced 1 minute, then the task will be fired off once and the next run
+  * be scheduled for 10 seconds later. This mirrors the behavior of the Akka scheduler when it cannot fire tasks off as
+  * quickly as it is asked to.
+  */
+class SimulatedScheduler(clock: FixedClock) extends Scheduler {
+  override def maxFrequency = 0.0
+  private[this] val nextId = new AtomicLong
+  private[this] val scheduledTasks = scala.collection.mutable.Map.empty[Long, ScheduledTask]
+  private case class ScheduledTask(action: () => Unit, var time: Long)
+  private class ScheduledTaskCancellable(id: Long) extends Cancellable {
+    override def cancel() = {
+      doCancel(id)
+      true
+    }
+    override def isCancelled = scheduledTasks.contains(id)
+  }
+
+  clock.onChange { () => poll() }
+
+  private[this] def doCancel(id: Long) = synchronized { scheduledTasks -= id }
+  private[this] def poll(): Unit = synchronized {
+    val now = clock.now().getMillis
+    scheduledTasks.values.foreach { task =>
+      if (task.time <= now) task.action()
+    }
+  }
+
+  override def scheduleOnce(
+    delay:    FiniteDuration,
+    runnable: Runnable
+  )(implicit executor: ExecutionContext): Cancellable = synchronized {
+    val id = nextId.getAndIncrement
+    val cancellable = new ScheduledTaskCancellable(id)
+    scheduledTasks(id) = ScheduledTask(
+      time = clock.now().getMillis + delay.toMillis,
+      action = () => {
+      cancellable.cancel()
+      executor.execute(runnable)
+    }
+    )
+    poll()
+    cancellable
+  }
+
+  def schedule(
+    initialDelay: FiniteDuration,
+    interval:     FiniteDuration,
+    runnable:     Runnable
+  )(implicit executor: ExecutionContext): Cancellable = synchronized {
+    val id = nextId.getAndIncrement
+    val cancellable = new ScheduledTaskCancellable(id)
+    scheduledTasks(id) = ScheduledTask(
+      time = clock.now().getMillis + initialDelay.toMillis,
+      action = () => {
+      scheduledTasks(id).time = clock.now().getMillis + interval.toMillis
+      executor.execute(runnable)
+    }
+    )
+    poll()
+    cancellable
+  }
+
+  def taskCount = synchronized { scheduledTasks.size }
+}

--- a/jobs/src/test/scala/dcos/metronome/SimulatedScheduler.scala
+++ b/jobs/src/test/scala/dcos/metronome/SimulatedScheduler.scala
@@ -45,17 +45,15 @@ class SimulatedScheduler(clock: FixedClock) extends Scheduler {
 
   override def scheduleOnce(
     delay:    FiniteDuration,
-    runnable: Runnable
-  )(implicit executor: ExecutionContext): Cancellable = synchronized {
+    runnable: Runnable)(implicit executor: ExecutionContext): Cancellable = synchronized {
     val id = nextId.getAndIncrement
     val cancellable = new ScheduledTaskCancellable(id)
     scheduledTasks(id) = ScheduledTask(
       time = clock.now().getMillis + delay.toMillis,
       action = () => {
-      cancellable.cancel()
-      executor.execute(runnable)
-    }
-    )
+        cancellable.cancel()
+        executor.execute(runnable)
+      })
     poll()
     cancellable
   }
@@ -63,17 +61,15 @@ class SimulatedScheduler(clock: FixedClock) extends Scheduler {
   def schedule(
     initialDelay: FiniteDuration,
     interval:     FiniteDuration,
-    runnable:     Runnable
-  )(implicit executor: ExecutionContext): Cancellable = synchronized {
+    runnable:     Runnable)(implicit executor: ExecutionContext): Cancellable = synchronized {
     val id = nextId.getAndIncrement
     val cancellable = new ScheduledTaskCancellable(id)
     scheduledTasks(id) = ScheduledTask(
       time = clock.now().getMillis + initialDelay.toMillis,
       action = () => {
-      scheduledTasks(id).time = clock.now().getMillis + interval.toMillis
-      executor.execute(runnable)
-    }
-    )
+        scheduledTasks(id).time = clock.now().getMillis + interval.toMillis
+        executor.execute(runnable)
+      })
     poll()
     cancellable
   }

--- a/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
@@ -7,6 +7,7 @@ import mesosphere.marathon.core.task.Task
 import org.joda.time.DateTime
 
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ Future, Promise }
 
 object JobRunServiceFixture {
@@ -31,8 +32,8 @@ object JobRunServiceFixture {
     override def listRuns(filter: (JobRun) => Boolean): Future[Iterable[StartedJobRun]] = {
       Future.successful(specs.values.filter(r => filter(r.jobRun)))
     }
-    override def startJobRun(jobSpec: JobSpec): Future[StartedJobRun] = {
-      val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, DateTime.now, None, Map.empty[Task.Id, JobRunTask])
+    override def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
+      val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, DateTime.now, None, startingDeadline, Map.empty[Task.Id, JobRunTask])
       val startedRun = StartedJobRun(run, Promise[JobResult].future)
       specs += run.id -> startedRun
       Future.successful(startedRun)

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -506,8 +506,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
 
     Given("a jobRunSpec with startingDeadline")
     val jobSpec = JobSpec(
-      id = JobId("/test")
-    )
+      id = JobId("/test"))
     val startingDeadline = Some(1 second)
     val (actor, jobRun) = f.setupInitialExecutorActor(Some(jobSpec), startingDeadline)
     f.persistenceActor.expectMsgType[JobRunPersistenceActor.Create]
@@ -528,8 +527,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
 
     Given("a jobRunSpec with startingDeadline")
     val jobSpec = JobSpec(
-      id = JobId("/test")
-    )
+      id = JobId("/test"))
     val startingDeadline = Some(1 second)
     val (actor, jobRun) = f.setupActiveExecutorActor(Some(jobSpec))
 
@@ -545,8 +543,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
 
     Given("a jobRunSpec with startingDeadline")
     val jobSpec = JobSpec(
-      id = JobId("/test")
-    )
+      id = JobId("/test"))
     val startingDeadline = Some(1 second)
     Given("a job run created one hour before now")
     val (actor, jobRun) = f.setupInitialExecutorActor(Some(jobSpec), startingDeadline,

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -90,7 +90,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val actor = f.serviceActor
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec)
+    actor ! TriggerJobRun(f.jobSpec, None)
 
     Then("The list of started job runs is returned")
     val started = expectMsgClass(classOf[StartedJobRun])
@@ -103,7 +103,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -119,7 +119,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job aborted")
@@ -135,7 +135,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -151,7 +151,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("A service with 2 jobRuns")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("An existing jobRun is queried")
@@ -181,8 +181,8 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val clock = new FixedClock(DateTime.parse("2016-06-01T08:50:12.000Z"))
 
     def run() = {
-      val jobRun = new JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, clock.now(), None, Map.empty[Task.Id, JobRunTask])
-      new StartedJobRun(jobRun, Future.successful(JobResult(jobRun)))
+      val jobRun = new JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, clock.now(), None, None, Map.empty[Task.Id, JobRunTask])
+      StartedJobRun(jobRun, Future.successful(JobResult(jobRun)))
     }
     val run1 = run()
     val run2 = run()

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActorTest.scala
@@ -59,7 +59,7 @@ class JobSpecSchedulerActorTest extends TestKit(ActorSystem("test")) with FunSui
     val nextRun = DateTime.parse("2016-06-01T08:52:00.000Z")
 
     When("The actor is created")
-    actor ! StartJob
+    actor ! StartJob(f.jobSpec.schedules.head)
 
     Then("The next run is rescheduled")
     eventually(actor.underlyingActor.scheduledAt should be(Some(nextRun)))
@@ -75,7 +75,7 @@ class JobSpecSchedulerActorTest extends TestKit(ActorSystem("test")) with FunSui
     val nextRun = DateTime.parse("2018-01-13T14:01:00.000Z")
 
     When("The actor is created")
-    actor ! StartJob
+    actor ! StartJob(f.jobSpec.schedules.head)
 
     Then("The next run is rescheduled")
     eventually(actor.underlyingActor.scheduledAt should be(Some(nextRun)))

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
@@ -28,7 +28,6 @@ class JobRunMarshallerTest extends FunSuite with Matchers {
       DateTime.parse("2004-09-06T08:50:12.000Z"),
       Some(DateTime.parse("2004-09-06T08:50:12.000Z")),
       Some(1 minute),
-      Map.empty
-    )
+      Map.empty)
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
@@ -4,6 +4,7 @@ package repository.impl.kv.marshaller
 import dcos.metronome.model._
 import org.joda.time.DateTime
 import org.scalatest.{ FunSuite, Matchers }
+import scala.concurrent.duration._
 
 class JobRunMarshallerTest extends FunSuite with Matchers {
   test("round-trip of a JobRun") {
@@ -26,6 +27,8 @@ class JobRunMarshallerTest extends FunSuite with Matchers {
       JobRunStatus.Active,
       DateTime.parse("2004-09-06T08:50:12.000Z"),
       Some(DateTime.parse("2004-09-06T08:50:12.000Z")),
-      Map.empty)
+      Some(1 minute),
+      Map.empty
+    )
   }
 }


### PR DESCRIPTION
Summary:
This implements startingDeadline - a property that was part of API but never did anything. Now it should not launch a job that was not able to launch until this timeout is reached.

JIRA issues: METRONOME-191

  