### PR TITLE
Make Docker.forcePullImage Optional

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -307,7 +307,7 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
 
   import scala.concurrent.duration._
 
-  def spec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds), docker = Some(DockerSpec("image", forcePullImage = true))))
+  def spec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds), docker = Some(DockerSpec("image", forcePullImage = Some(true)))))
   val CronSpec(cron) = "* * * * *"
   val schedule1 = ScheduleSpec("id1", cron)
   val jobSpec1 = spec("spec1")

--- a/jobs/src/main/scala/dcos/metronome/model/Container.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/Container.scala
@@ -2,5 +2,5 @@ package dcos.metronome.model
 
 trait Container
 
-case class DockerSpec(image: String, forcePullImage: Boolean = false) extends Container
+case class DockerSpec(image: String, forcePullImage: Option[Boolean] = Some(false)) extends Container
 

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -279,12 +279,12 @@ object RunSpecConversions {
 
   implicit class DockerSpecToProto(val dockerSpec: DockerSpec) extends AnyVal {
     def toProto: Protos.JobSpec.RunSpec.DockerSpec = {
-      Protos.JobSpec.RunSpec.DockerSpec.newBuilder().setImage(dockerSpec.image).setForcePullImage(dockerSpec.forcePullImage).build()
+      Protos.JobSpec.RunSpec.DockerSpec.newBuilder().setImage(dockerSpec.image).setForcePullImage(dockerSpec.forcePullImage.getOrElse(false)).build()
     }
   }
 
   implicit class ProtoToDockerSpec(val dockerSpec: Protos.JobSpec.RunSpec.DockerSpec) extends AnyVal {
-    def toModel: DockerSpec = DockerSpec(image = dockerSpec.getImage, forcePullImage = dockerSpec.getForcePullImage)
+    def toModel: DockerSpec = DockerSpec(image = dockerSpec.getImage, forcePullImage = Some(dockerSpec.getForcePullImage))
   }
 
   implicit class EnvironmentToProto(val environment: Map[String, String]) extends AnyVal {

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -71,7 +71,7 @@ object MarathonImplicits {
         case Some(dockerSpec) => Some(Container.Docker(
           image = dockerSpec.image,
           volumes = jobSpec.run.volumes.map(_.toMarathon),
-          forcePullImage = dockerSpec.forcePullImage
+          forcePullImage = dockerSpec.forcePullImage.getOrElse(false)
         ))
         case _ => None
       }

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -486,7 +486,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     Given("a jobRunSpec with forcePullImage")
     val jobSpec = JobSpec(
       id = JobId("/test"),
-      run = JobRunSpec(docker = Some(DockerSpec("image", forcePullImage = true)))
+      run = JobRunSpec(docker = Some(DockerSpec("image", forcePullImage = Some(true))))
     )
     val (_, jobRun) = f.setupInitialExecutorActor(Some(jobSpec))
 

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -40,7 +40,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers {
       placement = PlacementSpec(constraints = Seq(ConstraintSpec("hostname", Operator.Eq, Some("localhost")))),
       artifacts = Seq(Artifact("http://www.foo.bar/file.tar.gz", extract = false, executable = true, cache = true)),
       maxLaunchDelay = 24.hours,
-      docker = Some(DockerSpec(image = "dcos/metronome", true)),
+      docker = Some(DockerSpec(image = "dcos/metronome", Some(true))),
       volumes = Seq(
         Volume(containerPath = "/var/log", hostPath = "/sandbox/task1/var/log", mode = Mode.RW)
       ),


### PR DESCRIPTION
Make Docker.forcePullImage Optional

Summary:
making forcePullImage optional.  I thought Big B boolean would do it.  Apparently we need the Optional.
https://jira.mesosphere.com/browse/METRONOME-196

JIRA issues:  METRONOME-196
