### PR TITLE
Force pull image should not be required

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -133,7 +133,10 @@ package object models {
 
   implicit lazy val VolumeFormat: Format[Volume] = Json.format[Volume]
 
-  implicit lazy val DockerSpecFormat: Format[DockerSpec] = Json.format[DockerSpec]
+  implicit lazy val DockerSpecFormat: Format[DockerSpec] = (
+    (__ \ "image").format[String] ~
+    (__ \ "forcePullImage").formatNullable[Boolean].withDefault(false)
+  ) (DockerSpec.apply, unlift(DockerSpec.unapply))
 
   implicit lazy val RestartSpecFormat: Format[RestartSpec] = (
     (__ \ "policy").formatNullable[RestartPolicy].withDefault(RestartSpec.DefaultRestartPolicy) ~

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -29,6 +29,18 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       contentAsJson(response) mustBe jobSpec1Json
     }
 
+    "creates job when sending docker spec without forcePullImage property" in {
+      Given("Job spec without forcePullImage")
+      val specJson = "{\"id\":\"spec1\",\"run\":{\"cpus\":1,\"mem\":128,\"disk\":0,\"docker\":{\"image\":\"image\"}}}"
+
+      When("A job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(Json.parse(specJson))).get
+
+      Then("The job is created")
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+    }
+
     "ignore given schedules when sending a valid job spec with schedules" in {
       Given("No job")
 


### PR DESCRIPTION
Summary:
This is an alternative implementation to #166 which does not change the domain model because of json binding.
The reason why #166 was necessary is the implementation of Json.format - see https://www.playframework.com/documentation/2.5.18/api/scala/index.html#play.api.libs.json.Json$

To make sure it works I have added unit test that was failing prior to changing the model class...

JIRA issues: METRONOME-196