### PR TITLE
Fix of the flaky test in JobScheduleControllerTest

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -101,7 +101,7 @@ package object models {
       new Writes[ScheduleSpec] {
         override def writes(o: ScheduleSpec): JsValue =
           ScheduleSpecFormatBasic.writes(o).as[JsObject] ++
-            Json.obj("nextRunAt" -> o.nextExecution(DateTime.now(o.timeZone)))
+            Json.obj("nextRunAt" -> o.nextExecution())
       }
     )
   }

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -1,8 +1,10 @@
 package dcos.metronome.api.v1.controllers
 
+import java.time.{ Clock, Instant, ZoneOffset }
+
 import dcos.metronome.api._
 import dcos.metronome.api.v1.models._
-import dcos.metronome.model.{ JobId, CronSpec, JobSpec, ScheduleSpec }
+import dcos.metronome.model.{ CronSpec, JobId, JobSpec, ScheduleSpec }
 import mesosphere.marathon.core.plugin.PluginManager
 import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
 import org.scalatest.concurrent.ScalaFutures
@@ -318,10 +320,16 @@ class JobScheduleControllerTest extends PlaySpec with OneAppPerTestWithComponent
 
   override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Millis)))
 
+  val mockedClock = Clock.fixed(Instant.now, ZoneOffset.UTC)
+
   val CronSpec(cron1) = "* * * * *"
   val CronSpec(cron2) = "1 2 3 4 5"
-  val schedule1 = ScheduleSpec("id1", cron1)
-  val schedule2 = ScheduleSpec("id2", cron2)
+  val schedule1 = new ScheduleSpec("id1", cron1) {
+    override def clock = mockedClock
+  }
+  val schedule2 = new ScheduleSpec("id2", cron2) {
+    override def clock = mockedClock
+  }
   val schedule1Json = Json.toJson(schedule1)
   val schedule2Json = Json.toJson(schedule2)
   val specId = JobId("spec")

--- a/jobs/src/main/scala/dcos/metronome/model/ScheduleSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/ScheduleSpec.scala
@@ -1,5 +1,7 @@
 package dcos.metronome.model
 
+import java.time.Clock
+
 import com.wix.accord.Validator
 import com.wix.accord.dsl._
 import org.joda.time.{ DateTime, DateTimeZone }
@@ -14,12 +16,15 @@ case class ScheduleSpec(
     concurrencyPolicy: ConcurrencyPolicy = ScheduleSpec.DefaultConcurrencyPolicy,
     enabled:           Boolean           = ScheduleSpec.DefaultEnabled
 ) {
+  def clock: Clock = ScheduleSpec.DefaultClock
 
   def nextExecution(after: DateTime): DateTime = {
     val localAfter = after.toDateTime(timeZone)
     val localNext = cron.nextExecution(localAfter)
     localNext.toDateTime(DateTimeZone.UTC)
   }
+
+  def nextExecution(): DateTime = nextExecution(new DateTime(clock.instant().toEpochMilli, timeZone))
 }
 
 object ScheduleSpec {
@@ -27,6 +32,7 @@ object ScheduleSpec {
   val DefaultStartingDeadline = 15.minutes
   val DefaultConcurrencyPolicy = ConcurrencyPolicy.Allow
   val DefaultEnabled = true
+  val DefaultClock = Clock.systemUTC()
 
   implicit lazy val validScheduleSpec: Validator[ScheduleSpec] = validator[ScheduleSpec] { spec =>
     spec.startingDeadline >= 1.minute


### PR DESCRIPTION
Summary: added a clock instance to generate timestamps instead of using DateTime.now()

JIRA issues: METRONOME-198