### PR TITLE
Fix for Metronome Restart Starting Additional Jobs

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/JobsModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/JobsModule.scala
@@ -38,9 +38,8 @@ class JobsModule(
 
   lazy val jobRunModule = {
     val launchQueue = schedulerModule.launchQueueModule.launchQueue
-    val taskTracker = schedulerModule.taskTrackerModule.taskTracker
     val driverHolder = schedulerModule.schedulerDriverHolder
-    new JobRunModule(config, actorSystem, clock, repositoryModule.jobRunRepository, launchQueue, taskTracker, driverHolder, behaviorModule.behavior, schedulerModule.leadershipModule)
+    new JobRunModule(config, actorSystem, clock, repositoryModule.jobRunRepository, launchQueue, driverHolder, behaviorModule.behavior, schedulerModule.leadershipModule)
   }
 
   lazy val jobSpecModule = new JobSpecModule(

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunModule.scala
@@ -9,11 +9,9 @@ import dcos.metronome.repository.Repository
 import dcos.metronome.utils.time.Clock
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.launchqueue.LaunchQueue
-import mesosphere.marathon.core.task.tracker.TaskTracker
 import mesosphere.marathon.core.leadership.LeadershipModule
 
 import scala.concurrent.Promise
-import scala.concurrent.duration.Duration
 
 class JobRunModule(
   config:           JobRunConfig,
@@ -21,7 +19,6 @@ class JobRunModule(
   clock:            Clock,
   jobRunRepository: Repository[JobRunId, JobRun],
   launchQueue:      LaunchQueue,
-  taskTracker:      TaskTracker,
   driverHolder:     MarathonSchedulerDriverHolder,
   behavior:         Behavior,
   leadershipModule: LeadershipModule) {
@@ -32,7 +29,7 @@ class JobRunModule(
     val persistenceActorFactory = (id: JobRunId, context: ActorContext) =>
       context.actorOf(JobRunPersistenceActor.props(id, jobRunRepository, behavior))
     JobRunExecutorActor.props(jobRun, promise, persistenceActorFactory,
-      launchQueue, taskTracker, driverHolder, clock, behavior)(actorSystem.scheduler)
+      launchQueue, driverHolder, clock, behavior)(actorSystem.scheduler)
   }
 
   val jobRunServiceActor = leadershipModule.startWhenLeader(

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -2,7 +2,6 @@ package dcos.metronome
 package jobrun.impl
 
 import akka.actor.{ Actor, ActorContext, ActorLogging, ActorRef, Cancellable, Props, Scheduler, Stash }
-import dcos.metronome.{ JobRunFailed, UnexpectedTaskState }
 import dcos.metronome.behavior.{ ActorBehavior, Behavior }
 import dcos.metronome.eventbus.TaskStateChangedEvent
 import dcos.metronome.jobrun.StartedJobRun
@@ -12,12 +11,10 @@ import dcos.metronome.utils.time.Clock
 import mesosphere.marathon.MarathonSchedulerDriverHolder
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
-import mesosphere.marathon.core.task.Task.LaunchedEphemeral
-import mesosphere.marathon.core.task.tracker.TaskTracker
 import org.joda.time.Seconds
 
 import scala.concurrent.Promise
-import scala.concurrent.duration.{ Duration, FiniteDuration }
+import scala.concurrent.duration.FiniteDuration
 
 /**
   * Handles one job run from start until the job either completes successful or failed.
@@ -29,7 +26,6 @@ class JobRunExecutorActor(
   promise:                    Promise[JobResult],
   persistenceActorRefFactory: (JobRunId, ActorContext) => ActorRef,
   launchQueue:                LaunchQueue,
-  taskTracker:                TaskTracker,
   driverHolder:               MarathonSchedulerDriverHolder,
   clock:                      Clock,
   val behavior:               Behavior)(implicit scheduler: Scheduler) extends Actor with Stash with ActorLogging with ActorBehavior {
@@ -363,12 +359,11 @@ object JobRunExecutorActor {
     promise:                    Promise[JobResult],
     persistenceActorRefFactory: (JobRunId, ActorContext) => ActorRef,
     launchQueue:                LaunchQueue,
-    taskTracker:                TaskTracker,
     driverHolder:               MarathonSchedulerDriverHolder,
     clock:                      Clock,
     behavior:                   Behavior)(implicit scheduler: Scheduler): Props = Props(
     new JobRunExecutorActor(run, promise, persistenceActorRefFactory,
-      launchQueue, taskTracker, driverHolder, clock, behavior))
+      launchQueue, driverHolder, clock, behavior))
 }
 
 object TaskStates {


### PR DESCRIPTION
Fix for Metronome Restart Starting Additional Jobs

Summary:
Metronome if restarted while a JobRun was running upon startup would launch a new Task for the existing JobRun.  This would create a situation where there are tasks that it appeared Metronome wasn't aware of and it would put heavier demands on the cluster.
This initially looked like a reconciliation issue, however the reconciliation of known tasks looks fine with this fix.   There is still an issue IMO in the odd state where mesos think there is a metronome task but metronome has no record of it.  That will need to be address in another JIRA. 
A contributing factor is that it is expected that the launch queue contains all the launched tasks.  However that is not true after a restart.  All previously launched and running "active" tasks are not in the launch queue.

This PR resolves the issue of metronome starting another task on restart which resulted in 1 jobrun having multiple tasks associated with it which should never happen.   We allow multiple jobruns for a job but not multiple tasks for a jobrun.   It is always expected a 1 to 1 relationship for jobrun and task.    Another side effect of this bug is metronome would lose track of a task... this was a 2nd task for a jobrun.  When the 1st task completed it would be purged (besides history) from metronome which is the correct behavior however the 2nd (or more depending on the number of restarts) task would be running on mesos without metronome awareness.  This is resolved with this fix.

https://jira.mesosphere.com/browse/METRONOME-100
https://jira.mesosphere.com/browse/METRONOME-139
https://jira.mesosphere.com/browse/METRONOME-189

JIRA issues: METRONOME-100
