### PR TITLE
/v1/queue should only return jobruns that are deploying

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/queue/impl/LaunchQueueServiceImpl.scala
+++ b/jobs/src/main/scala/dcos/metronome/queue/impl/LaunchQueueServiceImpl.scala
@@ -11,7 +11,6 @@ import scala.collection.immutable.Seq
 class LaunchQueueServiceImpl(launchQueue: LaunchQueue) extends LaunchQueueService {
 
   override def list(): Seq[QueuedJobRunInfo] = {
-    launchQueue.list.map(_.toModel)
+    launchQueue.list.filter(_.inProgress == true).map(_.toModel)
   }
-
 }


### PR DESCRIPTION
/v1/queue should only return jobruns that are deploying

Summary:
queue request should only return tasks inprogress not tasks that actively running
https://jira.mesosphere.com/browse/METRONOME-190

JIRA issues: METRONOME-190
