### PR TITLE
Queue job runs should show just job run id

### DIFF
--- a/api/src/main/resources/public/api/v1/examples/queue_job_list.json
+++ b/api/src/main/resources/public/api/v1/examples/queue_job_list.json
@@ -3,10 +3,10 @@
     "jobId": "jobId",
     "runs": [
       {
-        "runId": "/jobId/20180103214004BPuOB"
+        "runId": "20180103214004BPuOB"
       },
       {
-        "runId": "/jobId/20180103214014JIT0Y"
+        "runId": "20180103214014JIT0Y"
       }
     ]
   }

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -249,7 +249,7 @@ package object models {
   implicit lazy val QueuedTaskInfoWrites: Writes[QueuedJobRunInfo] = new Writes[QueuedJobRunInfo] {
     //    output of queue is only runid
     override def writes(runInfo: QueuedJobRunInfo): JsValue = Json.obj(
-      "runId" -> JsString(runInfo.id.path.last))
+      "runId" -> JsString(runInfo.runId))
   }
 
   def queuedTaskInfoMap(job: String, queuedTaskList: Seq[QueuedJobRunInfo]): JsValue = {

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -249,7 +249,7 @@ package object models {
   implicit lazy val QueuedTaskInfoWrites: Writes[QueuedJobRunInfo] = new Writes[QueuedJobRunInfo] {
     //    output of queue is only runid
     override def writes(runInfo: QueuedJobRunInfo): JsValue = Json.obj(
-      "runId" -> JsString(runInfo.id.toString()))
+      "runId" -> JsString(runInfo.id.path.last))
   }
 
   def queuedTaskInfoMap(job: String, queuedTaskList: Seq[QueuedJobRunInfo]): JsValue = {

--- a/jobs/src/main/scala/dcos/metronome/model/QueuedJobRunInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/QueuedJobRunInfo.scala
@@ -7,12 +7,14 @@ import mesosphere.marathon.state.Timestamp
 import scala.collection.immutable.Map
 
 case class QueuedJobRunInfo(
+  // is the full id used by marathon which includes the jobid/runid example: /startdeadline/201801221711083L7i6
   id:                    PathId,
   tasksLost:             Int,
   backOffUntil:          Timestamp,
   run:                   JobRunSpec          = JobRunSpec(),
   acceptedResourceRoles: Option[Set[String]] = None) extends RunSpec {
   def jobid: String = id.path.head
+  lazy val runId: String = id.path.last
   override def user: Option[String] = run.user
   override def secrets: Map[String, Secret] = Map.empty
   override def env: Map[String, EnvVarValue] = mesosphere.marathon.state.EnvVarValue(run.env)

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/ZkJobSpecRepositoryTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/ZkJobSpecRepositoryTest.scala
@@ -1,12 +1,12 @@
 package dcos.metronome
 package repository.impl.kv
 
-import dcos.metronome.model.{JobId, JobSpec}
+import dcos.metronome.model.{ JobId, JobSpec }
 import dcos.metronome.utils.test.Mockito
 import mesosphere.util.state.PersistentStoreWithNestedPathsSupport
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.time.{ Millis, Seconds, Span }
 
 import concurrent.Future
 


### PR DESCRIPTION
Queue job runs should show just job run id

Summary:
current returned id exposes the marathon app id... we should just return what is known as the job runid.

https://jira.mesosphere.com/browse/METRONOME-190


JIRA issues:  METRONOME-190
