### PR TITLE
Support FORBID Concurrency Policy

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -221,7 +221,8 @@
           "concurrencyPolicy": {
             "type": "string",
             "enum": [
-              "ALLOW"
+              "ALLOW",
+              "FORBID"
             ],
             "description": "Defines the behavior if a job is started, before the current job has finished. ALLOW will launch a new job, even if there is an existing run."
           },

--- a/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
@@ -29,7 +29,7 @@
     },
     "concurrencyPolicy": {
       "type": "string",
-      "enum": ["ALLOW"],
+      "enum": ["ALLOW", "FORBID"],
       "description": "Defines the behavior if a job is started, before the current job has finished. ALLOW will launch a new job, even if there is an existing run."
     },
     "enabled": {

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -85,6 +85,7 @@ message JobSpec {
     enum ConcurrencyPolicy {
       UNKNOWN = 1;
       ALLOW = 2;
+      FORBID = 3;
     }
     optional ConcurrencyPolicy concurrency_policy = 5;
 

--- a/jobs/src/main/scala/dcos/metronome/model/ConcurrencyPolicy.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/ConcurrencyPolicy.scala
@@ -4,9 +4,11 @@ package model
 sealed trait ConcurrencyPolicy
 object ConcurrencyPolicy {
   case object Allow extends ConcurrencyPolicy
+  case object Forbid extends ConcurrencyPolicy
 
   val names: Map[String, ConcurrencyPolicy] = Map(
-    "ALLOW" -> Allow)
+    "ALLOW" -> Allow,
+    "FORBID" -> Forbid)
   val concurrencyPolicyNames: Map[ConcurrencyPolicy, String] = names.map{ case (a, b) => (b, a) }
 
   def name(concurrencyPolicy: ConcurrencyPolicy): String = concurrencyPolicyNames(concurrencyPolicy)

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/ZkJobSpecRepositoryTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/ZkJobSpecRepositoryTest.scala
@@ -1,12 +1,12 @@
 package dcos.metronome
 package repository.impl.kv
 
-import dcos.metronome.model.{JobId, JobSpec}
+import dcos.metronome.model.{ JobId, JobSpec }
 import dcos.metronome.utils.test.Mockito
 import mesosphere.util.state.PersistentStoreWithNestedPathsSupport
 import org.scalatest.FunSuite
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.time.{ Millis, Seconds, Span }
 
 import concurrent.Future
 


### PR DESCRIPTION
Support FORBID Concurrency Policy

Summary:
Support FORBID concurrency policy, which is to not allow the start of job run based on a schedule 
if there is currently a running job run for the job.
https://jira.mesosphere.com/browse/METRONOME-194

JIRA issues: METRONOME-194
