### PR TITLE
Support FORBID Concurrency Policy (Option 2)

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -221,7 +221,8 @@
           "concurrencyPolicy": {
             "type": "string",
             "enum": [
-              "ALLOW"
+              "ALLOW",
+              "FORBID"
             ],
             "description": "Defines the behavior if a job is started, before the current job has finished. ALLOW will launch a new job, even if there is an existing run."
           },

--- a/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/schedulespec.schema.json
@@ -29,7 +29,7 @@
     },
     "concurrencyPolicy": {
       "type": "string",
-      "enum": ["ALLOW"],
+      "enum": ["ALLOW", "FORBID"],
       "description": "Defines the behavior if a job is started, before the current job has finished. ALLOW will launch a new job, even if there is an existing run."
     },
     "enabled": {

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -69,6 +69,22 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       contentType(response) mustBe Some("application/json")
     }
 
+    "creates job when sending forbid concurrency property against v0" in {
+      Given("Job spec with a schedule containing a forbid concurrency policy")
+      val specJson =
+        """{"id":"spec1","run":{"cpus":1,"mem":128,"disk":0,"docker":{"image":"image"}}, "schedules": [
+          |{"id": "default","enabled": true,"cron": "* * * * *","timezone": "UTC","concurrencyPolicy": "FORBID"}
+          |]}""".stripMargin
+
+      When("A job is created")
+      val response = route(app, FakeRequest(POST, s"/v0/scheduled-jobs").withJsonBody(Json.parse(specJson))).get
+
+      Then("The job is created")
+      println(contentAsString(response))
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+    }
+
     "ignore given schedules when sending a valid job spec with schedules" in {
       Given("No job")
 

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -85,6 +85,7 @@ message JobSpec {
     enum ConcurrencyPolicy {
       UNKNOWN = 1;
       ALLOW = 2;
+      FORBID = 3;
     }
     optional ConcurrencyPolicy concurrency_policy = 5;
 

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
@@ -1,7 +1,7 @@
 package dcos.metronome
 package jobrun
 
-import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
+import dcos.metronome.model._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -41,7 +41,7 @@ trait JobRunService {
     * @param jobSpec the specification to run.
     * @return the started job run
     */
-  def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun]
+  def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun]
 
   /**
     * Kill a given job run by the given job run id.

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
@@ -41,7 +41,7 @@ trait JobRunService {
     * @param jobSpec the specification to run.
     * @return the started job run
     */
-  def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun]
+  def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun]
 
   /**
     * Kill a given job run by the given job run id.

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -64,12 +64,9 @@ class JobRunServiceActor(
   def triggerJobRun(spec: JobSpec, schedule: Option[ScheduleSpec], startingDeadline: Option[Duration]): Unit = {
     log.info(s"Trigger new JobRun for JobSpec: $spec")
 
-    val skipRun = schedule match {
-      case Some(schedule) => schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && runsForJob(spec.id).nonEmpty
-      case None           => false
-    }
+    val skipRun = schedule.exists(schedule => schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && runsForJob(spec.id).nonEmpty)
     if (skipRun) {
-      log.debug(s"SkippingB Scheduled run for ${spec.id} based on concurrency policy")
+      log.debug(s"Skipping scheduled run for ${spec.id} based on concurrency policy")
     } else {
       val jobRun = JobRun(JobRunId(spec), spec, JobRunStatus.Initial, clock.now(), None, startingDeadline, Map.empty)
       val startedJobRun = startJobRun(jobRun)

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -66,12 +66,9 @@ class JobRunServiceActor(
 
     val skipRun = schedule.exists(schedule => schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && runsForJob(spec.id).nonEmpty)
     if (skipRun) {
-      log.debug(s"Skipping scheduled run for ${spec.id} based on concurrency policy")
+      log.info(s"Skipping scheduled run for ${spec.id} based on concurrency policy")
     } else {
-      val startingDeadline: Option[Duration] = schedule match {
-        case Some(schedule) => Some(schedule.startingDeadline)
-        case _              => None
-      }
+      val startingDeadline: Option[Duration] = schedule.map(_.startingDeadline)
       val jobRun = JobRun(JobRunId(spec), spec, JobRunStatus.Initial, clock.now(), None, startingDeadline, Map.empty)
       val startedJobRun = startJobRun(jobRun)
       sender() ! startedJobRun
@@ -154,7 +151,7 @@ class JobRunServiceActor(
   }
 
   override def initialize(runs: List[JobRun]): Unit = {
-//    called from LoadContentOnStartup with job runs from zk
+    //    called from LoadContentOnStartup with job runs from zk
     runs.foreach(r => startJobRun(r))
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration.Duration
 class JobRunServiceActor(
   clock:           Clock,
   executorFactory: (JobRun, Promise[JobResult]) => Props,
-  val repo:        Repository[JobRunId, JobRun], //TODO: remove the repo
+  val repo:        Repository[JobRunId, JobRun],
   val behavior:    Behavior) extends Actor with LoadContentOnStartup[JobRunId, JobRun] with Stash with ActorBehavior {
 
   import JobRunExecutorActor._
@@ -154,7 +154,7 @@ class JobRunServiceActor(
   }
 
   override def initialize(runs: List[JobRun]): Unit = {
-    // FIXME: we should to wait until the Reconciliation has finished!
+//    called from LoadContentOnStartup with job runs from zk
     runs.foreach(r => startJobRun(r))
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
@@ -5,7 +5,7 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import dcos.metronome.jobrun.{ JobRunConfig, JobRunService, StartedJobRun }
-import dcos.metronome.model.{ JobId, JobRun, JobRunId, JobSpec }
+import dcos.metronome.model._
 
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
@@ -33,7 +33,7 @@ private[jobrun] class JobRunServiceDelegate(
     actorRef.ask(GetActiveJobRuns(jobId)).mapTo[Iterable[StartedJobRun]]
   }
 
-  override def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
-    actorRef.ask(TriggerJobRun(jobSpec, startingDeadline)).mapTo[StartedJobRun]
+  override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
+    actorRef.ask(TriggerJobRun(jobSpec, schedule, startingDeadline)).mapTo[StartedJobRun]
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
@@ -33,7 +33,7 @@ private[jobrun] class JobRunServiceDelegate(
     actorRef.ask(GetActiveJobRuns(jobId)).mapTo[Iterable[StartedJobRun]]
   }
 
-  override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
-    actorRef.ask(TriggerJobRun(jobSpec, schedule, startingDeadline)).mapTo[StartedJobRun]
+  override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun] = {
+    actorRef.ask(TriggerJobRun(jobSpec, schedule)).mapTo[StartedJobRun]
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
@@ -50,7 +50,7 @@ class JobSpecSchedulerActor(
 
   def runJob(schedule: ScheduleSpec): Unit = {
     log.info(s"Start next run of job ${spec.id}, which was scheduled for $scheduledAt")
-    runService.startJobRun(spec, Some(schedule), Some(schedule.startingDeadline))
+    runService.startJobRun(spec, Some(schedule))
     scheduleNextRun()
   }
 

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
@@ -51,23 +51,7 @@ class JobSpecSchedulerActor(
   def runJob(schedule: ScheduleSpec): Unit = {
     log.info(s"Start next run of job ${spec.id}, which was scheduled for $scheduledAt")
     runService.startJobRun(spec, Some(schedule), Some(schedule.startingDeadline))
-    //    if (!(schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && activeRunsForJobSpec())) {
-    //    } else {
-    //      log.debug(s"Skipping Scheduled run for ${spec.id} based on concurrency policy")
-    //    }
     scheduleNextRun()
-  }
-
-  def activeRunsForJobSpec(): Boolean = {
-    try {
-      val runResult = Await.result(runService.activeRuns(spec.id), 5.seconds)
-      log.debug(s"job ${spec.id} has active runs? ${runResult.nonEmpty}")
-      runResult.nonEmpty
-    } catch {
-      case _: Throwable =>
-        log.error("Timeout retrieving active runs.")
-        true
-    }
   }
 
   def scheduleNextRun(): Unit = {

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecSchedulerActor.scala
@@ -50,12 +50,11 @@ class JobSpecSchedulerActor(
 
   def runJob(schedule: ScheduleSpec): Unit = {
     log.info(s"Start next run of job ${spec.id}, which was scheduled for $scheduledAt")
-
-    if (!(schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && activeRunsForJobSpec())) {
-      runService.startJobRun(spec, Some(schedule.startingDeadline))
-    } else {
-      log.debug(s"Skipping Scheduled run for ${spec.id} based on concurrency policy")
-    }
+    runService.startJobRun(spec, Some(schedule), Some(schedule.startingDeadline))
+    //    if (!(schedule.concurrencyPolicy == ConcurrencyPolicy.Forbid && activeRunsForJobSpec())) {
+    //    } else {
+    //      log.debug(s"Skipping Scheduled run for ${spec.id} based on concurrency policy")
+    //    }
     scheduleNextRun()
   }
 

--- a/jobs/src/main/scala/dcos/metronome/model/ConcurrencyPolicy.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/ConcurrencyPolicy.scala
@@ -4,9 +4,11 @@ package model
 sealed trait ConcurrencyPolicy
 object ConcurrencyPolicy {
   case object Allow extends ConcurrencyPolicy
+  case object Forbid extends ConcurrencyPolicy
 
   val names: Map[String, ConcurrencyPolicy] = Map(
-    "ALLOW" -> Allow)
+    "ALLOW" -> Allow,
+    "FORBID" -> Forbid)
   val concurrencyPolicyNames: Map[ConcurrencyPolicy, String] = names.map{ case (a, b) => (b, a) }
 
   def name(concurrencyPolicy: ConcurrencyPolicy): String = concurrencyPolicyNames(concurrencyPolicy)

--- a/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
@@ -1,7 +1,6 @@
 package dcos.metronome
 package jobrun
 
-import dcos.metronome.JobRunDoesNotExist
 import dcos.metronome.model._
 import mesosphere.marathon.core.task.Task
 import org.joda.time.DateTime
@@ -33,10 +32,7 @@ object JobRunServiceFixture {
       Future.successful(specs.values.filter(r => filter(r.jobRun)))
     }
     override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun] = {
-      val startingDeadline: Option[Duration] = schedule match {
-        case Some(schedule) => Some(schedule.startingDeadline)
-        case _              => None
-      }
+      val startingDeadline: Option[Duration] = schedule.map(_.startingDeadline)
       val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, DateTime.now, None, startingDeadline, Map.empty[Task.Id, JobRunTask])
       val startedRun = StartedJobRun(run, Promise[JobResult].future)
       specs += run.id -> startedRun

--- a/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
@@ -32,7 +32,7 @@ object JobRunServiceFixture {
     override def listRuns(filter: (JobRun) => Boolean): Future[Iterable[StartedJobRun]] = {
       Future.successful(specs.values.filter(r => filter(r.jobRun)))
     }
-    override def startJobRun(jobSpec: JobSpec, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
+    override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
       val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, DateTime.now, None, startingDeadline, Map.empty[Task.Id, JobRunTask])
       val startedRun = StartedJobRun(run, Promise[JobResult].future)
       specs += run.id -> startedRun

--- a/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
@@ -32,7 +32,11 @@ object JobRunServiceFixture {
     override def listRuns(filter: (JobRun) => Boolean): Future[Iterable[StartedJobRun]] = {
       Future.successful(specs.values.filter(r => filter(r.jobRun)))
     }
-    override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, startingDeadline: Option[Duration] = None): Future[StartedJobRun] = {
+    override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun] = {
+      val startingDeadline: Option[Duration] = schedule match {
+        case Some(schedule) => Some(schedule.startingDeadline)
+        case _              => None
+      }
       val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, DateTime.now, None, startingDeadline, Map.empty[Task.Id, JobRunTask])
       val startedRun = StartedJobRun(run, Promise[JobResult].future)
       specs += run.id -> startedRun

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -90,7 +90,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val actor = f.serviceActor
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, None)
 
     Then("The list of started job runs is returned")
     val started = expectMsgClass(classOf[StartedJobRun])
@@ -103,7 +103,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -119,7 +119,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job aborted")
@@ -135,7 +135,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -151,7 +151,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("A service with 2 jobRuns")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("An existing jobRun is queried")

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -90,7 +90,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val actor = f.serviceActor
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec, None, None)
+    actor ! TriggerJobRun(f.jobSpec, None)
 
     Then("The list of started job runs is returned")
     val started = expectMsgClass(classOf[StartedJobRun])
@@ -103,7 +103,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None, None)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -119,7 +119,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None, None)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job aborted")
@@ -135,7 +135,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None, None)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -151,7 +151,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("A service with 2 jobRuns")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None, None)
+    actor ! TriggerJobRun(f.jobSpec, None)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("An existing jobRun is queried")

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -202,7 +202,6 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     eventually(actor.underlyingActor.allRunExecutors should have size 0)
   }
 
-
   override protected def afterAll(): Unit = {
     shutdown()
   }

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -99,6 +99,37 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     system.stop(actor)
   }
 
+  test("Triggering a jobRun with forbid policy and no job run works") {
+    Given("An empty service")
+    val f = new Fixture
+    val actor = f.serviceActor
+
+    When("An existing jobRun is queried")
+    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule))
+
+    Then("The list of started job runs is returned")
+    val started = expectMsgClass(classOf[StartedJobRun])
+    started.jobRun.jobSpec should be(f.jobSpec)
+    actor.underlyingActor.allJobRuns should have size 1
+    system.stop(actor)
+  }
+
+  test("Triggering a jobRun with forbid policy and a current job run does NOT start another job run") {
+    Given("A service with 1 jobRuns")
+    val f = new Fixture
+    val actor = f.serviceActor
+    // triggered job
+    actor ! TriggerJobRun(f.jobSpec, None)
+    val startedRun = expectMsgClass(classOf[StartedJobRun])
+
+    When("An existing jobRun is queried")
+    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule))
+
+    Then("No Job Started and No Returned StartedJobRun")
+    expectNoMsg()
+    actor.underlyingActor.allJobRuns should have size 1
+  }
+
   test("A finished job run will be removed from the registry") {
     Given("An empty service")
     val f = new Fixture
@@ -171,6 +202,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     eventually(actor.underlyingActor.allRunExecutors should have size 0)
   }
 
+
   override protected def afterAll(): Unit = {
     shutdown()
   }
@@ -178,6 +210,8 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
   class Fixture {
     val id = JobId("test")
     val jobSpec = JobSpec(id)
+    val forbidSchedule = ScheduleSpec("schedule", CronSpec("* * * * *"), ScheduleSpec.DefaultTimeZone, ScheduleSpec.DefaultStartingDeadline, ConcurrencyPolicy.Forbid)
+
     val clock = new FixedClock(DateTime.parse("2016-06-01T08:50:12.000Z"))
 
     def run() = {


### PR DESCRIPTION
Support FORBID Concurrency Policy (Option 2)

Summary:
Support FORBID concurrency policy, which is to not allow the start of job run based on a schedule 
if there is currently a running job run for the job.
https://jira.mesosphere.com/browse/METRONOME-194

#181 has blocking code in an actor awaiting another actor.   This version moves the logic to that dependent (and context aware) actor.   This removes the block, but puts some schedule logic in the `JobRunServiceActor` which mainly used for a view on all running job runs.

If we stick with this approach, I may be inclined to have the `schedule: Option[ScheduleSpec]` hold the value of the ` startingDeadline: Option[Duration]` but I'm not sure if that makes sense in all cases.

JIRA issues: METRONOME-194