### PR TITLE
Make the tests more stable by mocking time in Fixture

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -1,16 +1,18 @@
 package dcos.metronome
 package api.v1.controllers
 
-import java.time.{ Clock, Instant, ZoneOffset }
+import java.time.{Clock, Instant, ZoneOffset}
 
 import dcos.metronome.api._
 import dcos.metronome.api.v1.models._
+import dcos.metronome.jobspec.JobSpecService
+import dcos.metronome.jobspec.impl.JobSpecServiceFixture
 import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
-import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
+import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{BeforeAndAfter, GivenWhenThen}
 import org.scalatestplus.play.PlaySpec
 import play.api.ApplicationLoader.Context
 import play.api.libs.json._
@@ -360,5 +362,6 @@ class JobScheduleControllerTest extends PlaySpec with OneAppPerTestWithComponent
 
   override def createComponents(context: Context): MockApiComponents = new MockApiComponents(context) {
     override lazy val pluginManager: PluginManager = auth.pluginManager
+    override lazy val jobSpecService: JobSpecService = JobSpecServiceFixture.simpleJobSpecService(mockedClock)
   }
 }

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -1,7 +1,7 @@
 package dcos.metronome
 package api.v1.controllers
 
-import java.time.{Clock, Instant, ZoneOffset}
+import java.time.{ Clock, Instant, ZoneOffset }
 
 import dcos.metronome.api._
 import dcos.metronome.api.v1.models._
@@ -9,10 +9,10 @@ import dcos.metronome.jobspec.JobSpecService
 import dcos.metronome.jobspec.impl.JobSpecServiceFixture
 import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
-import org.scalatest.{BeforeAndAfter, GivenWhenThen}
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfter, GivenWhenThen}
+import org.scalatest.time.{ Millis, Seconds, Span }
+import org.scalatest.{ BeforeAndAfter, GivenWhenThen }
 import org.scalatestplus.play.PlaySpec
 import play.api.ApplicationLoader.Context
 import play.api.libs.json._

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
@@ -4,7 +4,7 @@ package jobspec.impl
 import java.time.Clock
 
 import dcos.metronome.jobspec.JobSpecService
-import dcos.metronome.model.{JobId, JobSpec, ScheduleSpec}
+import dcos.metronome.model.{ JobId, JobSpec, ScheduleSpec }
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
@@ -1,9 +1,10 @@
 package dcos.metronome
 package jobspec.impl
 
-import dcos.metronome.{ JobSpecAlreadyExists, JobSpecDoesNotExist }
+import java.time.Clock
+
 import dcos.metronome.jobspec.JobSpecService
-import dcos.metronome.model.{ JobId, JobSpec }
+import dcos.metronome.model.{JobId, JobSpec, ScheduleSpec}
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
@@ -11,7 +12,7 @@ import scala.util.control.NonFatal
 
 object JobSpecServiceFixture {
 
-  def simpleJobSpecService(): JobSpecService = new JobSpecService {
+  def simpleJobSpecService(testClock: Clock = Clock.systemUTC()): JobSpecService = new JobSpecService {
     val specs = TrieMap.empty[JobId, JobSpec]
     import Future._
     override def getJobSpec(id: JobId): Future[Option[JobSpec]] = successful(specs.get(id))
@@ -21,17 +22,21 @@ object JobSpecServiceFixture {
         case Some(_) =>
           failed(JobSpecAlreadyExists(jobSpec.id))
         case None =>
-          specs += jobSpec.id -> jobSpec
+          specs += jobSpec.id -> jobSpecWithMockedTime(jobSpec)
           successful(jobSpec)
       }
     }
+
+    private def jobSpecWithMockedTime(jobSpec: JobSpec): JobSpec = jobSpec.copy(schedules = jobSpec.schedules.map(s => new ScheduleSpec(s.id, s.cron, s.timeZone, s.startingDeadline, s.concurrencyPolicy, s.enabled) {
+      override def clock: Clock = testClock
+    }))
 
     override def updateJobSpec(id: JobId, update: (JobSpec) => JobSpec): Future[JobSpec] = {
       specs.get(id) match {
         case Some(spec) =>
           try {
             val changed = update(spec)
-            specs.update(id, changed)
+            specs.update(id, jobSpecWithMockedTime(changed))
             successful(changed)
           } catch {
             case NonFatal(ex) => failed(ex)


### PR DESCRIPTION
Summary:
More tests were flaky because of clock.now being used when serializing output json. E.g. this run https://jenkins.mesosphere.com/service/jenkins/view/Metronome/job/Metronome/job/metronome-pipelines/view/change-requests/job/PR-179/12/

JIRA issues:
