### PR TITLE
Make the forbid test not flaky

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -346,7 +346,9 @@ class JobScheduleControllerTest extends PlaySpec with OneAppPerTestWithComponent
   val schedule2 = new ScheduleSpec("id2", cron2) {
     override def clock = mockedClock
   }
-  val scheduleForbid = new ScheduleSpec("id3", cron1, ScheduleSpec.DefaultTimeZone, ScheduleSpec.DefaultStartingDeadline, ConcurrencyPolicy.Forbid)
+  val scheduleForbid = new ScheduleSpec("id3", cron1, ScheduleSpec.DefaultTimeZone, ScheduleSpec.DefaultStartingDeadline, ConcurrencyPolicy.Forbid) {
+    override def clock = mockedClock
+  }
   val schedule1Json = Json.toJson(schedule1)
   val schedule2Json = Json.toJson(schedule2)
   val schedule3Json = Json.toJson(scheduleForbid)


### PR DESCRIPTION
Summary:
We need to mock the clock.
Example failed run https://jenkins.mesosphere.com/service/jenkins/blue/rest/organizations/jenkins/pipelines/Metronome/pipelines/metronome-pipelines/branches/PR-189/runs/1/nodes/27/steps/30/log/?start=0
