### PR TITLE
Fix METRONOME-100 regression SI test

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -5,6 +5,7 @@ from dcos import http
 
 import shakedown
 import time
+import pytest
 
 from dcos import metronome
 
@@ -136,3 +137,20 @@ def assert_wait_for_no_additional_tasks(client, job_id, timeout=20, tasks_count=
     """
     time.sleep(timeout)
     assert_job_run(client, job_id, active_tasks_number=tasks_count)
+
+
+def not_required_masters_exact_count(count):
+    """ Returns True if the number of masters is equal to
+    the count.  This is useful in using pytest skipif such as:
+    `pytest.mark.skipif('required_masters(3)')` which will skip the test if
+    the number of masters is only 1.
+    :param count: the number of required masters.
+    """
+    master_count = len(shakedown.get_all_masters())
+    # reverse logic (skip if less than count)
+    # returns True if less than count
+    return master_count != count
+
+
+def masters_exact(count):
+    return pytest.mark.skipif('not_required_masters_exact_count({})'.format(count))

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -10,10 +10,9 @@ import common
 import shakedown
 import pytest
 
-from common import job_no_schedule, schedule
+from common import job_no_schedule, schedule, not_required_masters_exact_count # NOQA F401
 from dcos import metronome
 from retrying import retry
-from shakedown import required_masters # NOQA F401
 
 pytestmark = [pytest.mark.skipif("shakedown.dcos_version_less_than('1.8')")]
 
@@ -240,7 +239,8 @@ def test_docker_job():
         assert len(client.get_runs(job_id)) == 1
 
 
-@shakedown.masters(1)
+@common.masters_exact(1)
+@pytest.mark.skip(reason="we need to wait until METRONOME-100 gets to testing/master")
 def test_metronome_shutdown_with_no_extra_tasks():
     """ Test for METRONOME-100 regression
         When Metronome is restarted it incorrectly started another task for already running job run task.


### PR DESCRIPTION
Summary:

- shakedown.masters is actually true if masters count is greater than that number, so not what I wanted
- we need to skip the test until METRONOME-100 fix is in testing/master or until METRONOME-202 is done

JIRA issues: METRONOME-100
