### PR TITLE
Wait for metronome, not mesos after shutdown

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -88,6 +88,19 @@ def wait_for_mesos_endpoint(timeout_sec=timedelta(minutes=5).total_seconds()):
     return shakedown.time_wait(lambda: shakedown.mesos_available_predicate(), timeout_seconds=timeout_sec)
 
 
+def wait_for_metronome(timeout_sec=timedelta(minutes=5).total_seconds()):
+    """ Waits for the Metronome API url to be available for a given timeout.
+        It needs to succeed as many times as we have masters because that means that all adminrouters on all masters
+        are probably aware of the restarted leader.
+        Without this in multimaster setup this can be very flaky.
+    """
+
+    master_count = len(shakedown.get_all_masters())
+    shakedown.time_wait(lambda: metronome_available_predicate(),
+                        timeout_seconds=timeout_sec,
+                        required_consecutive_success_count=master_count)
+
+
 def metronome_available_predicate():
     url = metronome_api_url()
     try:

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -89,16 +89,10 @@ def wait_for_mesos_endpoint(timeout_sec=timedelta(minutes=5).total_seconds()):
 
 
 def wait_for_metronome(timeout_sec=timedelta(minutes=5).total_seconds()):
-    """ Waits for the Metronome API url to be available for a given timeout.
-        It needs to succeed as many times as we have masters because that means that all adminrouters on all masters
-        are probably aware of the restarted leader.
-        Without this in multimaster setup this can be very flaky.
-    """
+    """ Waits for the Metronome API url to be available for a given timeout. """
 
-    master_count = len(shakedown.get_all_masters())
     shakedown.time_wait(lambda: metronome_available_predicate(),
-                        timeout_seconds=timeout_sec,
-                        required_consecutive_success_count=master_count)
+                        timeout_seconds=timeout_sec)
 
 
 def metronome_available_predicate():

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -103,7 +103,7 @@ def wait_for_metronome():
     url = metronome_api_url()
     try:
         response = http.get(url)
-        assert response.status_code == 200, f"Expecting Metronome service to be up but it did not get healthy after 5 minutes. Last response: {response}"
+        assert response.status_code == 200, f"Expecting Metronome service to be up but it did not get healthy after 5 minutes. Last response: {response.content}"
     except Exception as e:
         assert False, f"Expecting Metronome service to be up but it did not get healthy after 5 minutes. Last exception: {e}"
 

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -125,7 +125,7 @@ def test_disable_schedule_recovery_from_master_bounce():
 
         # # bounce master
         shakedown.restart_master_node()
-        common.wait_for_metronome(timedelta(minutes=10).total_seconds())
+        common.wait_for_metronome()
 
         # wait for the next run
         time.sleep(timedelta(minutes=1.5).total_seconds())
@@ -258,7 +258,7 @@ def test_metronome_shutdown_with_no_extra_tasks():
         # we can improve this one there is a good way how to get metronome leader from the system (e.g. info endpoint)
         metronome_leader = shakedown.master_leader_ip()
         shakedown.run_command_on_agent(metronome_leader, 'sudo systemctl restart dcos-metronome')
-        common.wait_for_metronome(timeout_sec=timedelta(minutes=1).total_seconds())
+        common.wait_for_metronome()
 
         # verify that no extra job runs were started when Metronome was restarted
         common.assert_wait_for_no_additional_tasks(tasks_count=1, client=client, job_id=job_id)
@@ -279,4 +279,7 @@ def job(job_json):
     try:
         yield
     finally:
-        client.remove_job(job_id, True)
+        try:
+            client.remove_job(job_id, True)
+        except Exception as e:
+            print(e)

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -125,7 +125,7 @@ def test_disable_schedule_recovery_from_master_bounce():
 
         # # bounce master
         shakedown.restart_master_node()
-        common.wait_for_mesos_endpoint(timedelta(minutes=10).total_seconds())
+        common.wait_for_metronome(timedelta(minutes=10).total_seconds())
 
         # wait for the next run
         time.sleep(timedelta(minutes=1.5).total_seconds())
@@ -258,8 +258,7 @@ def test_metronome_shutdown_with_no_extra_tasks():
         # we can improve this one there is a good way how to get metronome leader from the system (e.g. info endpoint)
         metronome_leader = shakedown.master_leader_ip()
         shakedown.run_command_on_agent(metronome_leader, 'sudo systemctl restart dcos-metronome')
-        shakedown.time_wait(lambda: common.metronome_available_predicate(),
-                            timeout_seconds=timedelta(minutes=1).total_seconds())
+        common.wait_for_metronome(timeout_sec=timedelta(minutes=1).total_seconds())
 
         # verify that no extra job runs were started when Metronome was restarted
         common.assert_wait_for_no_additional_tasks(tasks_count=1, client=client, job_id=job_id)


### PR DESCRIPTION
Summary:
It was supposed to be fix for multimaster cluster, now it's just probably a PR that will make the debugging easier by better error messages. Also now we are waiting for Metronome, not just Mesos (which can make a difference but might now).

JIRA issues: METRONOME-230
