### PR TITLE
HTTP 500 Errors Based on ZK Storage

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/repository/LoadContentOnStartup.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/LoadContentOnStartup.scala
@@ -2,6 +2,7 @@ package dcos.metronome
 package repository
 
 import akka.actor.{ Actor, ActorLogging, Stash }
+import mesosphere.marathon.StoreCommandFailedException
 
 import scala.concurrent.Future
 import scala.util.{ Failure, Success }
@@ -33,7 +34,7 @@ trait LoadContentOnStartup[Id, Model] extends Actor with Stash with ActorLogging
     val loadAllFuture = repo.ids().flatMap { ids =>
       ids.foldLeft(Future.successful(List.empty[Model])) {
         case (resultsFuture, id) => resultsFuture.flatMap { res =>
-          repo.get(id).map(_.map(_ :: res).getOrElse(res))
+          getModel(id).map(_.map(_ :: res).getOrElse(res))
         }
       }
     }
@@ -43,6 +44,14 @@ trait LoadContentOnStartup[Id, Model] extends Actor with Stash with ActorLogging
       case Failure(ex) =>
         log.error(ex, "Can not load initial data. Give up.")
         throw ex
+    }
+  }
+
+  private def getModel(id: Id): Future[Option[Model]] = {
+    repo.get(id).recoverWith {
+      case ex: StoreCommandFailedException =>
+        log.error(s"ID $id is a dangling path with data recovery issues.  Exception message: ${ex.getMessage}")
+        Future { None }
     }
   }
 }


### PR DESCRIPTION
HTTP 500 Errors Based on ZK Storage

Summary:
The `LoadContentOnStartup` trait has a `loadAll` function in it's `preStart`.   It is possible for the  `loadAll` function to throw a `StoreCommandFailedException` (which is in the documentation for the repo.get).   This caused the `JobRunServiceActor` which is of type LoadContentOnStart to fail to start.   This caused controller calls for JobSpecs (such as get a list of jobspecs) to timeout since the actor never responded to a request for 10s.  In this state, Metronome would never work correctly until the zk was cleared.

There are 2 reasonable reasons for this situation to occur:

1. The zk path for `job-spec`/some-job-id was created, however the process was killed prior to the job spec data being added to the zk path.  We do NOT use zk transactions.  The twitter zk lib we use does not expose them.
2. The data stored at a zk path is corrupt.

The change included in this PR provides error handling around data loading.   It will "skip" dangling paths or paths with corrupt data.

https://jira.mesosphere.com/browse/METRONOME-218

JIRA issues:   METRONOME-218
