### PR TITLE
Additional cron validation

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/CronSpecFormatTest.scala
@@ -182,6 +182,17 @@ class CronSpecFormatTest extends FunSuite with Mockito with Matchers {
     nextCronDate shouldEqual new DateTime(2018, 2, 20, 0, 0)
   }
 
+  test("Not fail when leap year is possible") {
+    val cronString = "0 0 29 2 *"
+
+    val spec = CronSpec(cronString)
+    val currentDateTime: DateTime = new DateTime(2017, 10, 2, 10, 0)
+
+    val nextCronDate = spec.nextExecution(currentDateTime)
+
+    nextCronDate shouldEqual new DateTime(2020, 2, 29, 0, 0)
+  }
+
   test("Invalid cron because february and march both don't have 31 days") {
     val cronString = "0 0 31 2-3 *"
 

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -121,6 +121,21 @@ class JobScheduleControllerTest extends PlaySpec with OneAppPerTestWithComponent
       Then("a forbidden response is send")
       status(unauthorized) mustBe FORBIDDEN
     }
+
+    // regression of METRONOME-236
+    "end with validation error for invalid cron" in {
+      Given("A job")
+      route(app, FakeRequest(POST, "/v1/jobs").withJsonBody(jobSpecJson)).get.futureValue
+
+      When("Invalid schedule is sent")
+      val invalid = schedule2Json.as[JsObject] ++ Json.obj("cron" -> "0 0 31 2 *")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs/$specId/schedules").withJsonBody(invalid)).get
+
+      Then("A validation problem is indicated")
+      status(response) mustBe UNPROCESSABLE_ENTITY
+      contentType(response) mustBe Some("application/json")
+      (contentAsJson(response) \ "message").as[String] mustBe "Object is not valid"
+    }
   }
 
   "GET /jobs/{id}/schedules" should {

--- a/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/CronSpec.scala
@@ -79,12 +79,12 @@ object CronSpec {
 }
 
 object CronSpecValidation {
-  val validDayOfMonth = "Day of the month must exist in the provided month and year (e.g. February have only < 29 days so running cron on 30.2. is invalid)"
+  val validDayOfMonth = "Day of the month must exist in the provided month (e.g. February has only <= 29 days so running cron on Feb 30 is invalid)"
 }
 
 /**
-  * In the existing validation logic inside cron-utils there is not validation that the given day exist in a month.
-  * This validator covers that use case disallowing schedules like 0 0 31 2 * (run on 31.2.)
+  * Day of month validation is missing from cron-utils which will cause it to search endlessly for a day that doesn't exist.
+  * This validator covers that use case disallowing schedules like 0 0 31 2 * (run on Feb 31.)
   */
 class CronDaysInMonthValidation extends CronConstraint(CronSpecValidation.validDayOfMonth) {
   def daysExistInAMonths(days: Seq[Int], months: Seq[Int]): Boolean = {
@@ -92,7 +92,7 @@ class CronDaysInMonthValidation extends CronConstraint(CronSpecValidation.validD
   }
   val maxDaysOfMonth = Array(31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
   def dayExistInAMonth(day: Int, month: Int): Boolean = {
-    day < maxDaysOfMonth(month - 1)
+    day <= maxDaysOfMonth(month - 1)
   }
 
   def getValuesFromCron(field: CronField): Seq[Int] = field.getExpression match {


### PR DESCRIPTION
Summary:
Submitting invalid CRON like '0 0 31 2 *' (run on 31.2.) basically made the whole Metronome unresponsive. Core of this issue lies in the cron-utils library we use.
It does some basic validation of cron fields but not anything on this level.
As a result, when we call nextExecution, there is a while loop looking for a next schedule that spins up the CPU and keeps the whole system busy (maybe even never terminating).
The proper fix for this is patching cron-utils (adding validation as well as fixing the nextExecution method).
I would do that ^^^ but I first implemented the validation logic inside Metronome itself (it uses the same abstraction as will be used inside the library) and I also added tests proving that it works now :-) (e.g. the controller test was timing out prior to my fix)

JIRA issues: METRONOME-236
