### PR TITLE
Secrets with Older Metrics

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -99,7 +99,17 @@
           "patternProperties": {
             ".*": {
               "oneOf": [
-                { "type": "string" }
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "description": "An environment variable set to a secret",
+                  "properties": {
+                    "secret": {
+                      "type": "string",
+                      "documentation": "The name of the secret to refer to. At runtime, the value of the secret will be injected into the value of the variable."
+                    }
+                  }
+                }
               ]
             }
           }
@@ -190,6 +200,21 @@
               }
             },
             "required": ["containerPath", "hostPath", "mode"]
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "description": "An environment variable set to a secret",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "documentation": "The name of the secret to refer to. At runtime, the value of the secret will be injected into the value of the variable."
+                }
+              }
+            }
           }
         }
       },

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -100,7 +100,18 @@
           "patternProperties": {
             ".*": {
               "oneOf": [
-                { "type": "string" }
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "description": "An environment variable set to a secret",
+                  "properties": {
+                    "secret": {
+                      "type": "string",
+                      "documentation": "The name of the secret to refer to. At runtime, the value of the secret will be injected into the value of the variable."
+                    }
+                  }
+                }
+
               ]
             }
           }
@@ -196,6 +207,21 @@
               }
             },
             "required": ["containerPath", "hostPath", "mode"]
+          }
+        },
+        "secrets": {
+          "type": "object",
+          "patternProperties": {
+            ".*": {
+              "type": "object",
+              "description": "An environment variable set to a secret",
+              "properties": {
+                "source": {
+                  "type": "string",
+                  "documentation": "The name of the secret to refer to. At runtime, the value of the secret will be injected into the value of the variable."
+                }
+              }
+            }
           }
         }
       },

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -153,14 +153,15 @@ package object models {
     (__ \ "cmd").formatNullable[String] ~
     (__ \ "args").formatNullable[Seq[String]] ~
     (__ \ "user").formatNullable[String] ~
-    (__ \ "env").formatNullable[Map[String, String]].withDefault(JobRunSpec.DefaultEnv) ~
+    (__ \ "env").formatNullable[Map[String, EnvVarValueOrSecret]].withDefault(JobRunSpec.DefaultEnv) ~
     (__ \ "placement").formatNullable[PlacementSpec].withDefault(JobRunSpec.DefaultPlacement) ~
     (__ \ "artifacts").formatNullable[Seq[Artifact]].withDefault(JobRunSpec.DefaultArtifacts) ~
     (__ \ "maxLaunchDelay").formatNullable[Duration].withDefault(JobRunSpec.DefaultMaxLaunchDelay) ~
     (__ \ "docker").formatNullable[DockerSpec] ~
     (__ \ "volumes").formatNullable[Seq[Volume]].withDefault(JobRunSpec.DefaultVolumes) ~
     (__ \ "restart").formatNullable[RestartSpec].withDefault(JobRunSpec.DefaultRestartSpec) ~
-    (__ \ "taskKillGracePeriodSeconds").formatNullable[FiniteDuration])(JobRunSpec.apply, unlift(JobRunSpec.unapply))
+    (__ \ "taskKillGracePeriodSeconds").formatNullable[FiniteDuration] ~
+    (__ \ "secrets").formatNullable[Map[String, SecretDef]].withDefault(JobRunSpec.DefaultSecrets))(JobRunSpec.apply, unlift(JobRunSpec.unapply))
 
   implicit lazy val JobSpecFormat: Format[JobSpec] = (
     (__ \ "id").format[JobId] ~

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -141,6 +141,42 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       Then("a forbidden response is send")
       status(unauthorized) mustBe FORBIDDEN
     }
+
+    "create a job with secrets" in {
+      Given("No job")
+
+      When("A job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSecretsJson)).get
+
+      Then("The job is created")
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+      contentAsJson(response) mustBe jobSpecWithSecretsJson
+    }
+
+    "indicate a problem when creating a job without a secret definition" in {
+      Given("No job")
+
+      When("A job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSecretVarsOnlyJson)).get
+
+      Then("A validation error is returned")
+      status(response) mustBe UNPROCESSABLE_ENTITY
+      contentType(response) mustBe Some("application/json")
+      //      contentAsJson(response) \ "message" mustBe JsDefined(JsString("Object is not valid"))
+    }
+
+    "indicate a problem when creating a job without a secret name" in {
+      Given("No job")
+
+      When("A job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSecretDefsOnlyJson)).get
+
+      Then("A validation error is returned")
+      status(response) mustBe UNPROCESSABLE_ENTITY
+      contentType(response) mustBe Some("application/json")
+      //      contentAsJson(response) \ "message" mustBe JsDefined(JsString("Object is not valid"))
+    }
   }
 
   "GET /jobs" should {
@@ -380,6 +416,21 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
   val jobSpec1Json = Json.toJson(jobSpec1)
   val jobSpec2 = spec("spec2")
   val jobSpec2Json = Json.toJson(jobSpec2)
+  val jobSpecWithSecrets = {
+    val jobSpec = spec("spec-with-secrets")
+    jobSpec.copy(run = jobSpec.run.copy(env = Map("secretVar" -> EnvVarSecret("secretId")), secrets = Map("secretId" -> SecretDef("source"))))
+  }
+  val jobSpecWithSecretVarsOnly = {
+    val jobSpec = spec("spec-with-secret-vars-only")
+    jobSpec.copy(run = jobSpec.run.copy(env = Map("secretVar" -> EnvVarSecret("secretId"))))
+  }
+  val jobSpecWithSecretDefsOnly = {
+    val jobSpec = spec("spec-with-secret-defs-only")
+    jobSpec.copy(run = jobSpec.run.copy(secrets = Map("secretId" -> SecretDef("source"))))
+  }
+  val jobSpecWithSecretsJson = Json.toJson(jobSpecWithSecrets)
+  val jobSpecWithSecretVarsOnlyJson = Json.toJson(jobSpecWithSecretVarsOnly)
+  val jobSpecWithSecretDefsOnlyJson = Json.toJson(jobSpecWithSecretDefsOnly)
   val auth = new TestAuthFixture
 
   before {

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -190,6 +190,21 @@ message JobSpec {
     // https://github.com/mesosphere/marathon/blob/releases/1.3/docs/docs/rest-api/public/api/v2/schema/AppDefinition.json
     // int64 in mesos and int32 in marathon... going with int64
     optional int64 task_kill_grace_period_seconds = 14;
+
+    // key value pair used to store secrets path
+    message EnvironmentVariableSecret {
+      optional string name = 1;
+      optional string secretId = 2;
+    }
+    repeated EnvironmentVariableSecret environmentSecrets = 15;
+
+    // key value pair used to store secrets path
+    message Secret {
+      optional string id = 1;
+      optional string source = 2;
+    }
+    repeated Secret secrets = 16;
+
   }
   optional RunSpec run = 6;
 }

--- a/jobs/src/main/scala/dcos/metronome/model/EnvVarValueOrSecret.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/EnvVarValueOrSecret.scala
@@ -1,0 +1,41 @@
+package dcos.metronome.model
+
+trait EnvVarValueOrSecret
+
+case class EnvVarValue(value: String) extends EnvVarValueOrSecret
+
+object EnvVarValue {
+  implicit object playJsonFormat extends play.api.libs.json.Format[EnvVarValue] {
+    def reads(json: play.api.libs.json.JsValue): play.api.libs.json.JsResult[EnvVarValue] = {
+      json.validate[String].map(EnvVarValue.apply)
+    }
+    def writes(envVarValue: EnvVarValue): play.api.libs.json.JsValue = {
+      play.api.libs.json.JsString(envVarValue.value)
+    }
+  }
+}
+
+/**
+  * An environment variable set to a secret
+  * @param secret The name of the secret to refer to. At runtime, the value of the
+  *   secret will be injected into the value of the variable.
+  */
+case class EnvVarSecret(secret: String) extends EnvVarValueOrSecret
+
+object EnvVarSecret {
+  implicit val playJsonFormat = play.api.libs.json.Json.format[EnvVarSecret]
+}
+
+object EnvVarValueOrSecret {
+  implicit object playJsonFormat extends play.api.libs.json.Format[EnvVarValueOrSecret] {
+    def reads(json: play.api.libs.json.JsValue): play.api.libs.json.JsResult[EnvVarValueOrSecret] = {
+      json.validate[EnvVarValue].orElse(json.validate[EnvVarSecret])
+    }
+    def writes(envOrSecret: EnvVarValueOrSecret): play.api.libs.json.JsValue = {
+      envOrSecret match {
+        case envVarValue: EnvVarValue   => play.api.libs.json.Json.toJson(envVarValue)(EnvVarValue.playJsonFormat)
+        case envVarSecret: EnvVarSecret => play.api.libs.json.Json.toJson(envVarSecret)(EnvVarSecret.playJsonFormat)
+      }
+    }
+  }
+}

--- a/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
@@ -12,20 +12,21 @@ import scala.collection.immutable._
 case class Artifact(uri: String, extract: Boolean = true, executable: Boolean = false, cache: Boolean = false)
 
 case class JobRunSpec(
-  cpus:                       Double                 = JobRunSpec.DefaultCpus,
-  mem:                        Double                 = JobRunSpec.DefaultMem,
-  disk:                       Double                 = JobRunSpec.DefaultDisk,
-  cmd:                        Option[String]         = JobRunSpec.DefaultCmd,
-  args:                       Option[Seq[String]]    = JobRunSpec.DefaultArgs,
-  user:                       Option[String]         = JobRunSpec.DefaultUser,
-  env:                        Map[String, String]    = JobRunSpec.DefaultEnv,
-  placement:                  PlacementSpec          = JobRunSpec.DefaultPlacement,
-  artifacts:                  Seq[Artifact]          = JobRunSpec.DefaultArtifacts,
-  maxLaunchDelay:             Duration               = JobRunSpec.DefaultMaxLaunchDelay,
-  docker:                     Option[DockerSpec]     = JobRunSpec.DefaultDocker,
-  volumes:                    Seq[Volume]            = JobRunSpec.DefaultVolumes,
-  restart:                    RestartSpec            = JobRunSpec.DefaultRestartSpec,
-  taskKillGracePeriodSeconds: Option[FiniteDuration] = JobRunSpec.DefaultTaskKillGracePeriodSeconds)
+  cpus:                       Double                           = JobRunSpec.DefaultCpus,
+  mem:                        Double                           = JobRunSpec.DefaultMem,
+  disk:                       Double                           = JobRunSpec.DefaultDisk,
+  cmd:                        Option[String]                   = JobRunSpec.DefaultCmd,
+  args:                       Option[Seq[String]]              = JobRunSpec.DefaultArgs,
+  user:                       Option[String]                   = JobRunSpec.DefaultUser,
+  env:                        Map[String, EnvVarValueOrSecret] = JobRunSpec.DefaultEnv,
+  placement:                  PlacementSpec                    = JobRunSpec.DefaultPlacement,
+  artifacts:                  Seq[Artifact]                    = JobRunSpec.DefaultArtifacts,
+  maxLaunchDelay:             Duration                         = JobRunSpec.DefaultMaxLaunchDelay,
+  docker:                     Option[DockerSpec]               = JobRunSpec.DefaultDocker,
+  volumes:                    Seq[Volume]                      = JobRunSpec.DefaultVolumes,
+  restart:                    RestartSpec                      = JobRunSpec.DefaultRestartSpec,
+  taskKillGracePeriodSeconds: Option[FiniteDuration]           = JobRunSpec.DefaultTaskKillGracePeriodSeconds,
+  secrets:                    Map[String, SecretDef]           = JobRunSpec.DefaultSecrets)
 
 object JobRunSpec {
   val DefaultCpus: Double = 1.0
@@ -36,12 +37,13 @@ object JobRunSpec {
   val DefaultCmd = None
   val DefaultArgs = None
   val DefaultUser = None
-  val DefaultEnv = Map.empty[String, String]
+  val DefaultEnv = Map.empty[String, EnvVarValueOrSecret]
   val DefaultArtifacts = Seq.empty[Artifact]
   val DefaultDocker = None
   val DefaultVolumes = Seq.empty[Volume]
   val DefaultRestartSpec = RestartSpec()
   val DefaultTaskKillGracePeriodSeconds = None
+  val DefaultSecrets = Map.empty[String, SecretDef]
 
   implicit lazy val validJobRunSpec: Validator[JobRunSpec] = new Validator[JobRunSpec] {
     import com.wix.accord._
@@ -58,4 +60,7 @@ object JobRunSpec {
 
 object JobRunSpecMessages {
   val cmdOrDockerValidation = "Cmd or docker image must be specified"
+  def secretsValidation(envVarSecretsName: Set[String], providedSecretsNames: Set[String]) = {
+    s"Secret names are different from provided secrets. Defined: ${envVarSecretsName.mkString(", ")}, Provided: ${providedSecretsNames.mkString(", ")}"
+  }
 }

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -7,7 +7,10 @@ import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon.plugin.{ Secret, EnvVarValue, RunSpec }
 
 import scala.collection.immutable._
-import JobRunSpec._
+import dcos.metronome.model.JobRunSpec._
+import dcos.metronome.utils.glue.MarathonConversions
+import mesosphere.marathon.api.v2.Validation._
+import mesosphere.marathon
 
 case class JobSpec(
   id:          JobId,
@@ -17,10 +20,10 @@ case class JobSpec(
   run:         JobRunSpec          = JobSpec.DefaultRunSpec) extends RunSpec {
   def schedule(id: String): Option[ScheduleSpec] = schedules.find(_.id == id)
 
-  override def user: Option[String] = run.user
-  override def acceptedResourceRoles: Option[Predef.Set[String]] = None
-  override def secrets: Map[String, Secret] = Map.empty
-  override def env: Map[String, EnvVarValue] = mesosphere.marathon.state.EnvVarValue(run.env)
+  override val user: Option[String] = run.user
+  override val acceptedResourceRoles: Option[Predef.Set[String]] = None
+  override val secrets: Map[String, Secret] = MarathonConversions.secretsToMarathon(run.secrets)
+  override val env: Map[String, marathon.state.EnvVarValue] = MarathonConversions.envVarToMarathon(run.env)
 }
 
 object JobSpec {

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -4,7 +4,7 @@ package model
 import com.wix.accord.dsl._
 import com.wix.accord.Validator
 import mesosphere.marathon.api.v2.Validation._
-import mesosphere.marathon.plugin.{ Secret, EnvVarValue, RunSpec }
+import mesosphere.marathon.plugin.{ Secret, RunSpec }
 
 import scala.collection.immutable._
 import dcos.metronome.model.JobRunSpec._

--- a/jobs/src/main/scala/dcos/metronome/model/QueuedJobRunInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/QueuedJobRunInfo.scala
@@ -1,7 +1,9 @@
 package dcos.metronome
 package model
 
-import mesosphere.marathon.plugin.{ EnvVarValue, PathId, RunSpec, Secret }
+import dcos.metronome.utils.glue.MarathonConversions
+import mesosphere.marathon.plugin.{ PathId, Secret, RunSpec }
+import mesosphere.marathon.plugin
 import mesosphere.marathon.state.Timestamp
 
 import scala.collection.immutable.Map
@@ -17,6 +19,6 @@ case class QueuedJobRunInfo(
   lazy val runId: String = id.path.last
   override def user: Option[String] = run.user
   override def secrets: Map[String, Secret] = Map.empty
-  override def env: Map[String, EnvVarValue] = mesosphere.marathon.state.EnvVarValue(run.env)
-  override def labels = Map.empty[String, String]
+  override val env: Map[String, plugin.EnvVarValue] = MarathonConversions.envVarToMarathon(run.env)
+  override val labels = Map.empty[String, String]
 }

--- a/jobs/src/main/scala/dcos/metronome/model/SecretDef.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/SecretDef.scala
@@ -1,0 +1,26 @@
+package dcos.metronome.model
+
+/**
+  * A secret declaration
+  * @param source reference to a secret which will be injected with a value from the secret store.
+  */
+case class SecretDef(source: String)
+
+object SecretDef {
+  import play.api.libs.json.Reads._
+  implicit object playJsonFormat extends play.api.libs.json.Format[SecretDef] {
+    def reads(json: play.api.libs.json.JsValue): play.api.libs.json.JsResult[SecretDef] = {
+      val source = json.\("source").validate[String](play.api.libs.json.JsPath.read[String](minLength[String](ConstraintSourceMinLength)))
+      val _errors = Seq(("source", source)).collect({
+        case (field, e: play.api.libs.json.JsError) => e.repath(play.api.libs.json.JsPath.\(field)).asInstanceOf[play.api.libs.json.JsError]
+      })
+      if (_errors.nonEmpty) _errors.reduceOption[play.api.libs.json.JsError](_.++(_)).getOrElse(_errors.head)
+      else play.api.libs.json.JsSuccess(SecretDef(source = source.get))
+    }
+    def writes(secret: SecretDef): play.api.libs.json.JsValue = {
+      val source = play.api.libs.json.Json.toJson(secret.source)
+      play.api.libs.json.JsObject(Seq(("source", source)).filter(_._2 != play.api.libs.json.JsNull).++(Seq.empty))
+    }
+  }
+  val ConstraintSourceMinLength = 1
+}

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonConversions.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonConversions.scala
@@ -1,0 +1,19 @@
+package dcos.metronome.utils.glue
+
+import dcos.metronome.model.{ EnvVarSecret, EnvVarValue, EnvVarValueOrSecret, SecretDef }
+import mesosphere.marathon
+
+object MarathonConversions {
+
+  def envVarToMarathon(envVars: Map[String, EnvVarValueOrSecret]): Map[String, marathon.state.EnvVarValue] = {
+    envVars.mapValues {
+      case EnvVarValue(value)   => marathon.state.EnvVarString(value)
+      case EnvVarSecret(secret) => marathon.state.EnvVarSecretRef(secret)
+    }
+  }
+
+  def secretsToMarathon(secrets: Map[String, SecretDef]): Map[String, marathon.state.Secret] = {
+    secrets.map { case (name, value) => name -> marathon.state.Secret(value.source) }
+  }
+
+}

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -4,11 +4,10 @@ package utils.glue
 import java.util.concurrent.TimeUnit
 
 import dcos.metronome.model._
-import dcos.metronome.scheduler.SchedulerConfig
 import mesosphere.marathon
 import mesosphere.marathon.core.health.HealthCheck
 import mesosphere.marathon.core.readiness.ReadinessCheck
-import mesosphere.marathon.state.{ AppDefinition, Container, EnvVarValue, FetchUri, PathId, PortDefinition, RunSpec, Secret, UpgradeStrategy }
+import mesosphere.marathon.state.{ AppDefinition, Container, FetchUri, PathId, PortDefinition, RunSpec, Secret, UpgradeStrategy }
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
@@ -87,7 +86,7 @@ object MarathonImplicits {
         cmd = jobSpec.run.cmd,
         args = jobSpec.run.args,
         user = jobSpec.run.user,
-        env = EnvVarValue(jobSpec.run.env),
+        env = MarathonConversions.envVarToMarathon(jobSpec.run.env),
         instances = 1,
         cpus = jobSpec.run.cpus,
         mem = jobSpec.run.mem,
@@ -112,7 +111,7 @@ object MarathonImplicits {
         ipAddress = None,
         versionInfo = AppDefinition.VersionInfo.NoVersion,
         residency = None,
-        secrets = Map.empty[String, Secret])
+        secrets = MarathonConversions.secretsToMarathon(jobSpec.run.secrets))
     }
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -3,94 +3,27 @@ package repository.impl.kv.marshaller
 
 import dcos.metronome.model._
 import org.joda.time.DateTimeZone
-import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.{ FunSuite, Matchers }
-import org.scalatest.prop.PropertyChecks
 
 import scala.collection.immutable._
-import scala.concurrent.duration.FiniteDuration
 
-class JobSpecMarshallerTest extends FunSuite with Matchers with PropertyChecks {
+class JobSpecMarshallerTest extends FunSuite with Matchers {
+  test("round-trip of a complete JobSpec with cmd") {
+    val f = new Fixture
+    JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(f.jobSpec)) should be (Some(f.jobSpec))
+  }
+
+  test("round-trip of a complete JobSpec with args") {
+    val f = new Fixture
+
+    val jobSpec = f.jobSpec.copy(
+      run = f.runSpec.copy(cmd = None, args = Some(Seq("first", "second"))))
+    JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(f.jobSpec)) should be (Some(f.jobSpec))
+  }
 
   test("unmarshal with invalid proto data should return None") {
     val invalidBytes = "foobar".getBytes
     JobSpecMarshaller.fromBytes(invalidBytes) should be (None)
-  }
-
-  val nonEmptyAlphaStrGen = Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
-
-  val constrantsSpecGen = for {
-    attribute <- nonEmptyAlphaStrGen
-    operator <- Gen.oneOf(Operator.Eq, Operator.Like, Operator.Unlike)
-    value <- Gen.option(nonEmptyAlphaStrGen)
-  } yield ConstraintSpec(
-    attribute,
-    operator,
-    value)
-
-  val placementGen = for {
-    constraints <- Gen.listOf(constrantsSpecGen)
-  } yield PlacementSpec(
-    constraints)
-
-  val booleanGen = Gen.oneOf(true, false)
-
-  val durationGen = Gen.posNum[Long].map(l => FiniteDuration(l, "second"))
-
-  val jobRunSpecGen = for {
-    cpus <- Gen.posNum[Double]
-    mem <- Gen.posNum[Double]
-    disk <- Gen.posNum[Double]
-    cmd <- Gen.option(nonEmptyAlphaStrGen)
-    args <- Gen.option(Gen.nonEmptyListOf(nonEmptyAlphaStrGen))
-    user <- Gen.option(nonEmptyAlphaStrGen)
-    env <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, Gen.oneOf(nonEmptyAlphaStrGen.map(v => EnvVarValue(v)), nonEmptyAlphaStrGen.map(v => EnvVarSecret(v)))))
-    placement <- placementGen
-    artifacts <- Gen.listOf(Gen.zip(nonEmptyAlphaStrGen, booleanGen, booleanGen, booleanGen).map { case (s, b1, b2, b3) => Artifact(s, b1, b2, b3) })
-    maxLaunchDelay <- durationGen
-    docker <- Gen.option(Gen.zip(nonEmptyAlphaStrGen, booleanGen).map{ case (s, b) => DockerSpec(s, b) })
-    volumes <- Gen.listOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen, Gen.oneOf(Mode.RO, Mode.RW)).map{ case (s1, s2, m) => Volume(s1, s2, m) })
-    restart <- Gen.zip(Gen.oneOf(RestartPolicy.Never, RestartPolicy.OnFailure), Gen.option(durationGen)).map{ case (rp, d) => RestartSpec(rp, d) }
-    taskKillGracePeriodSeconds <- Gen.option(durationGen)
-    secrets <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen.map(s => SecretDef(s))))
-  } yield JobRunSpec(
-    cpus,
-    mem,
-    disk,
-    cmd,
-    args,
-    user,
-    env,
-    placement,
-    artifacts,
-    maxLaunchDelay,
-    docker,
-    volumes,
-    restart,
-    taskKillGracePeriodSeconds,
-    secrets)
-
-  val jobSpecGen = for {
-    id <- Gen.listOf(nonEmptyAlphaStrGen).map(s => JobId(s))
-    description <- Gen.option(nonEmptyAlphaStrGen)
-    labels <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen))
-    schedules <- Gen.listOf(for {
-      id <- nonEmptyAlphaStrGen
-      cron <- Gen.const(CronSpec("* * * * *"))
-      timeZone <- Gen.const(org.joda.time.DateTimeZone.UTC)
-      startingDeadline <- durationGen
-      concurrencyPolicy <- Gen.const(ConcurrencyPolicy.Allow)
-      enabled <- booleanGen
-    } yield ScheduleSpec(id, cron, timeZone, startingDeadline, concurrencyPolicy, enabled))
-    run <- jobRunSpecGen
-  } yield JobSpec(id, description, labels, schedules, run)
-
-  implicit val jobSpecArbitrary = Arbitrary(jobSpecGen)
-
-  test("round-trip of a complete JobSpec") {
-    forAll (jobSpecGen) { jobSpec =>
-      JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(jobSpec)) shouldEqual Some(jobSpec)
-    }
   }
 
   class Fixture {
@@ -103,7 +36,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with PropertyChecks {
       cmd = Some("sleep 500"),
       args = None,
       user = Some("root"),
-      env = Map("key" -> EnvVarValue("value"), "secretName" -> EnvVarSecret("secretId")),
+      env = Map("key" -> EnvVarValue("value")),
       placement = PlacementSpec(constraints = Seq(ConstraintSpec("hostname", Operator.Eq, Some("localhost")))),
       artifacts = Seq(Artifact("http://www.foo.bar/file.tar.gz", extract = false, executable = true, cache = true)),
       maxLaunchDelay = 24.hours,
@@ -111,8 +44,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with PropertyChecks {
       volumes = Seq(
         Volume(containerPath = "/var/log", hostPath = "/sandbox/task1/var/log", mode = Mode.RW)),
       restart = RestartSpec(policy = RestartPolicy.OnFailure, activeDeadline = Some(15.days)),
-      taskKillGracePeriodSeconds = Some(10 seconds),
-      secrets = Map("secretId" -> SecretDef("source")))
+      taskKillGracePeriodSeconds = Some(10 seconds))
 
     val jobSpec = JobSpec(
       id = JobId("/foo/bar"),

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -3,27 +3,94 @@ package repository.impl.kv.marshaller
 
 import dcos.metronome.model._
 import org.joda.time.DateTimeZone
+import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest.{ FunSuite, Matchers }
+import org.scalatest.prop.PropertyChecks
 
 import scala.collection.immutable._
+import scala.concurrent.duration.FiniteDuration
 
-class JobSpecMarshallerTest extends FunSuite with Matchers {
-  test("round-trip of a complete JobSpec with cmd") {
-    val f = new Fixture
-    JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(f.jobSpec)) should be (Some(f.jobSpec))
-  }
-
-  test("round-trip of a complete JobSpec with args") {
-    val f = new Fixture
-
-    val jobSpec = f.jobSpec.copy(
-      run = f.runSpec.copy(cmd = None, args = Some(Seq("first", "second"))))
-    JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(f.jobSpec)) should be (Some(f.jobSpec))
-  }
+class JobSpecMarshallerTest extends FunSuite with Matchers with PropertyChecks {
 
   test("unmarshal with invalid proto data should return None") {
     val invalidBytes = "foobar".getBytes
     JobSpecMarshaller.fromBytes(invalidBytes) should be (None)
+  }
+
+  val nonEmptyAlphaStrGen = Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
+
+  val constrantsSpecGen = for {
+    attribute <- nonEmptyAlphaStrGen
+    operator <- Gen.oneOf(Operator.Eq, Operator.Like, Operator.Unlike)
+    value <- Gen.option(nonEmptyAlphaStrGen)
+  } yield ConstraintSpec(
+    attribute,
+    operator,
+    value)
+
+  val placementGen = for {
+    constraints <- Gen.listOf(constrantsSpecGen)
+  } yield PlacementSpec(
+    constraints)
+
+  val booleanGen = Gen.oneOf(true, false)
+
+  val durationGen = Gen.posNum[Long].map(l => FiniteDuration(l, "second"))
+
+  val jobRunSpecGen = for {
+    cpus <- Gen.posNum[Double]
+    mem <- Gen.posNum[Double]
+    disk <- Gen.posNum[Double]
+    cmd <- Gen.option(nonEmptyAlphaStrGen)
+    args <- Gen.option(Gen.nonEmptyListOf(nonEmptyAlphaStrGen))
+    user <- Gen.option(nonEmptyAlphaStrGen)
+    env <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, Gen.oneOf(nonEmptyAlphaStrGen.map(v => EnvVarValue(v)), nonEmptyAlphaStrGen.map(v => EnvVarSecret(v)))))
+    placement <- placementGen
+    artifacts <- Gen.listOf(Gen.zip(nonEmptyAlphaStrGen, booleanGen, booleanGen, booleanGen).map { case (s, b1, b2, b3) => Artifact(s, b1, b2, b3) })
+    maxLaunchDelay <- durationGen
+    docker <- Gen.option(Gen.zip(nonEmptyAlphaStrGen, booleanGen).map{ case (s, b) => DockerSpec(s, b) })
+    volumes <- Gen.listOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen, Gen.oneOf(Mode.RO, Mode.RW)).map{ case (s1, s2, m) => Volume(s1, s2, m) })
+    restart <- Gen.zip(Gen.oneOf(RestartPolicy.Never, RestartPolicy.OnFailure), Gen.option(durationGen)).map{ case (rp, d) => RestartSpec(rp, d) }
+    taskKillGracePeriodSeconds <- Gen.option(durationGen)
+    secrets <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen.map(s => SecretDef(s))))
+  } yield JobRunSpec(
+    cpus,
+    mem,
+    disk,
+    cmd,
+    args,
+    user,
+    env,
+    placement,
+    artifacts,
+    maxLaunchDelay,
+    docker,
+    volumes,
+    restart,
+    taskKillGracePeriodSeconds,
+    secrets)
+
+  val jobSpecGen = for {
+    id <- Gen.listOf(nonEmptyAlphaStrGen).map(s => JobId(s))
+    description <- Gen.option(nonEmptyAlphaStrGen)
+    labels <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen))
+    schedules <- Gen.listOf(for {
+      id <- nonEmptyAlphaStrGen
+      cron <- Gen.const(CronSpec("* * * * *"))
+      timeZone <- Gen.const(org.joda.time.DateTimeZone.UTC)
+      startingDeadline <- durationGen
+      concurrencyPolicy <- Gen.const(ConcurrencyPolicy.Allow)
+      enabled <- booleanGen
+    } yield ScheduleSpec(id, cron, timeZone, startingDeadline, concurrencyPolicy, enabled))
+    run <- jobRunSpecGen
+  } yield JobSpec(id, description, labels, schedules, run)
+
+  implicit val jobSpecArbitrary = Arbitrary(jobSpecGen)
+
+  test("round-trip of a complete JobSpec") {
+    forAll (jobSpecGen) { jobSpec =>
+      JobSpecMarshaller.fromBytes(JobSpecMarshaller.toBytes(jobSpec)) shouldEqual Some(jobSpec)
+    }
   }
 
   class Fixture {
@@ -36,7 +103,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers {
       cmd = Some("sleep 500"),
       args = None,
       user = Some("root"),
-      env = Map("key" -> "value"),
+      env = Map("key" -> EnvVarValue("value"), "secretName" -> EnvVarSecret("secretId")),
       placement = PlacementSpec(constraints = Seq(ConstraintSpec("hostname", Operator.Eq, Some("localhost")))),
       artifacts = Seq(Artifact("http://www.foo.bar/file.tar.gz", extract = false, executable = true, cache = true)),
       maxLaunchDelay = 24.hours,
@@ -44,7 +111,8 @@ class JobSpecMarshallerTest extends FunSuite with Matchers {
       volumes = Seq(
         Volume(containerPath = "/var/log", hostPath = "/sandbox/task1/var/log", mode = Mode.RW)),
       restart = RestartSpec(policy = RestartPolicy.OnFailure, activeDeadline = Some(15.days)),
-      taskKillGracePeriodSeconds = Some(10 seconds))
+      taskKillGracePeriodSeconds = Some(10 seconds),
+      secrets = Map("secretId" -> SecretDef("source")))
 
     val jobSpec = JobSpec(
       id = JobId("/foo/bar"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -54,6 +54,7 @@ object Build extends sbt.Build {
         Dependency.metrics,
         Dependency.jsonValidate,
         Dependency.Test.scalatest,
+        Dependency.Test.scalaCheck,
         Dependency.Test.scalatestPlay
       )
     )
@@ -75,7 +76,9 @@ object Build extends sbt.Build {
         Dependency.akka,
         Dependency.metrics,
         Dependency.Test.akkaTestKit,
-        Dependency.Test.mockito
+        Dependency.Test.mockito,
+        Dependency.Test.scalatest,
+        Dependency.Test.scalaCheck
       )
     )
   )
@@ -135,6 +138,7 @@ object Build extends sbt.Build {
       // Test deps versions
       val AsyncAwait = "0.9.7"
       val ScalaTest = "2.2.6"
+      val ScalaCheck = "1.13.4"
       val MacWire = "2.2.2"
       val Marathon = "1.3.13"
       val Play = "2.5.18"
@@ -166,6 +170,7 @@ object Build extends sbt.Build {
     object Test {
       val scalatest = "org.scalatest" %% "scalatest" % V.ScalaTest % "test"
       val scalatestPlay = "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % "test"
+      val scalaCheck = "org.scalacheck" %% "scalacheck" % V.ScalaCheck % "test"
       val akkaTestKit = "com.typesafe.akka" %%  "akka-testkit" % V.Akka % "test"
       val mockito = "org.mockito" % "mockito-core" % V.Mockito % "test"
     }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -365,7 +365,7 @@ metronome {
   # "vips" (Currently n/a) can be used to enable the networking VIP integration UI.
   # "task_killing" can be used to enable the TASK_KILLING state in Mesos (0.28 or later)
   # "external_volumes" (Currently n/a) can be used if the cluster is configured to use external volumes.
-  # Example: --enable_features vips,task_killing,external_volumes
+  # Example: --enable_features vips,task_killing,external_volumes,secrets
   features.enable = ${?METRONOME_FEATURES_ENABLE}
 
   # (Optional. Default: "metronome") Framework name used to register with mesos.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1"
+version in ThisBuild := "0.4.2"


### PR DESCRIPTION
Secrets with Older Metrics

Summary:
This is a back port of secrets which landed on metronome 0.5.0.  However metronome 0.5.0 has new kamon metrics and is viewed as a breaking change to DCOS 1.10.   This will be released as Metronome 0.4.2 which is 0.4.1 + Secrets.

JIRA issues:  METRONOME-248
