### PR TITLE
bump marathon to 1.6.352 (latest)

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -170,8 +170,7 @@ object Build extends sbt.Build {
       val ScalaTest = "3.0.5"
       val ScalaCheck = "1.13.4"
       val MacWire = "2.2.5"
-      val Marathon = "1.6.340"
-      val MarathonPluginInterface = "1.6.340"
+      val Marathon = "1.6.352"
       val Play = "2.6.7"
       val CronUtils = "6.0.4"
       val Threeten = "1.3.3"
@@ -193,7 +192,7 @@ object Build extends sbt.Build {
     val macWireUtil = "com.softwaremill.macwire" %% "util" % V.MacWire
     val macWireProxy = "com.softwaremill.macwire" %% "proxy" % V.MacWire
     val marathon = "mesosphere.marathon" %% "marathon" % V.Marathon exclude("com.typesafe.play", "*") exclude("mesosphere.marathon", "ui") exclude("mesosphere", "chaos") exclude("org.apache.hadoop", "hadoop-hdfs") exclude("org.apache.hadoop", "hadoop-common") exclude("org.eclipse.jetty", "*") exclude("mesosphere.marathon", "plugin-interface_2.12")
-    val marathonPlugin = "mesosphere.marathon" %% "plugin-interface" % V.MarathonPluginInterface
+    val marathonPlugin = "mesosphere.marathon" %% "plugin-interface" % V.Marathon
     val cronUtils = "com.cronutils" % "cron-utils" % V.CronUtils exclude("org.threeten", "threetenbp")
     val threeten = "org.threeten" % "threetenbp" % V.Threeten
     val wixAccord = "com.wix" %% "accord-core" % V.WixAccord


### PR DESCRIPTION
bump marathon to 1.6.352 (latest)

Summary:
bump marathon to 1.6.352 (latest) and plugin and marathon versions shouldn't be different

JIRA issues:
