### PR TITLE
Allow Docker Params for Job Runs BP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,11 @@ sandboxes.tar.gz
 .DS_Store
 protobuf-*/
 *.tar.gz
+
+# si_provision.sh files
+ci/launch_cluster.sh
+ci/si_pipeline.sh
+
+# metrics needs
+jobs/native/
+native/

--- a/api/src/main/resources/public/api/v0/examples/job.json
+++ b/api/src/main/resources/public/api/v0/examples/job.json
@@ -27,7 +27,8 @@
     "mem": 32,
     "disk": 128,
     "docker": {
-      "image": "foo/bla:test"
+      "image": "foo/bla:test",
+      "privileged": true
     },
     "env": {
       "MON": "test",

--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -90,6 +90,27 @@
             "forcePullImage": {
               "type": "boolean",
               "documentation": "The containerizer will pull the image from the registry, even if the image is already downloaded on the agent node."
+            },
+            "privileged": {
+              "type": "boolean",
+              "documentation": "Run this docker image in privileged mode"
+            },
+            "parameters": {
+              "type": "array",
+              "description": "",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["key", "value"]
+              }
             }
           },
           "required": ["image"]

--- a/api/src/main/resources/public/api/v1/examples/job_docker_param.json
+++ b/api/src/main/resources/public/api/v1/examples/job_docker_param.json
@@ -1,0 +1,22 @@
+{
+  "description": "example docker parameters job",
+  "id": "docker-param",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "parameters": [
+        {
+          "key": "cap-drop",
+          "value": "ALL"
+        },
+        {
+          "key": "cap-add",
+          "value": "SYSLOG"
+        }
+      ]
+    }
+  }
+}

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -91,6 +91,27 @@
             "forcePullImage": {
               "type": "boolean",
               "documentation": "The containerizer will pull the image from the registry, even if the image is already downloaded on the agent."
+            },
+            "privileged": {
+              "type": "boolean",
+              "documentation": "Run this docker image in privileged mode"
+            },
+            "parameters": {
+              "type": "array",
+              "description": "",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["key", "value"]
+              }
             }
           },
           "required": ["image"]

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -4,11 +4,11 @@ title: Docker Run Configurations
 
 # Docker
 
-It is possible now to run jobs using docker's privilege mode and/or using docker run time parameters.  These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+It is now possible to run jobs using Docker's privilege mode and/or using Docker runtime parameters. These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
 
 ## Privileged Mode
 
-Running docker in privileged mode is possible by setting `privileged=true` in the docker section of the job definition.
+Running Docker container in privileged mode is possible by setting `privileged: true` in the Docker section of the job definition.
 
 ```
 {
@@ -28,7 +28,7 @@ Running docker in privileged mode is possible by setting `privileged=true` in th
 
 ## Docker Parameters
 
-It is possible to set docker parameters now with job runs.   This enables the ability to change runtime capabilities of the job.   The example below removes all the default docker capabilities and adds SYSLOG.
+It is possible to set Docker parameters now with job runs. This makes it possible to change runtime capabilities of the job. The example below removes all the default docker capabilities and adds SYSLOG.
 
 ```
 {

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -1,0 +1,56 @@
+---
+title: Docker Run Configurations
+---
+
+# Docker
+
+It is possible now to run jobs using docker's privilege mode and/or using docker run time parameters.  These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+
+## Privileged Mode
+
+Running docker in privileged mode is possible by setting `privileged=true` in the docker section of the job definition.
+
+```
+{
+  "description": "example docker that runs in privilege mode",
+  "id": "docker-priv",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "privileged": true
+    }
+  }
+}
+```
+
+## Docker Parameters
+
+It is possible to set docker parameters now with job runs.   This enables the ability to change runtime capabilities of the job.   The example below removes all the default docker capabilities and adds SYSLOG.
+
+```
+{
+  "description": "example docker that changes runtime capabilities",
+  "id": "docker-param",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "parameters": [
+        {
+          "key": "cap-drop",
+          "value": "ALL"
+        },
+        {
+          "key": "cap-add",
+          "value": "SYSLOG"
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,5 +15,9 @@ Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.10
 ## Contributing
 Learn how to [contribute to the Metronome project]({{ site.baseurl }}/docs/contributing.html).
 
+## Controlling Docker Runtime Capabilities
+Learn how to [change dockers runtime capabilities]({{ site.baseurl }}/docs/docker.html).
+
+
 ## API Reference
 Use the [Metronome REST API]({{ site.baseurl }}/docs/generated/api.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,13 @@ title: Cron Service for DC/OS
 </div>
 
 ## Documentation
-Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.10/deploying-jobs/).
+Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.11/deploying-jobs/).
 
 ## Contributing
 Learn how to [contribute to the Metronome project]({{ site.baseurl }}/docs/contributing.html).
 
 ## Controlling Docker Runtime Capabilities
-Learn how to [change dockers runtime capabilities]({{ site.baseurl }}/docs/docker.html).
-
+Learn how to [change docker runtime capabilities]({{ site.baseurl }}/docs/docker.html).
 
 ## API Reference
 Use the [Metronome REST API]({{ site.baseurl }}/docs/generated/api.html)

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -13,6 +13,14 @@ message Label {
   optional string value = 2;
 }
 
+/**
+ * A generic (key, value) pair used in various places for parameters.
+ */
+message Parameter {
+  required string key = 1;
+  required string value = 2;
+}
+
 message JobHistory {
   optional string job_spec_id = 1;
   optional int64 success_count = 2;
@@ -147,6 +155,9 @@ message JobSpec {
       // is already downloaded on the agent.
       optional bool force_pull_image = 2;
 
+      optional bool privileged = 3 [default = false];
+
+      repeated Parameter parameters = 4;
     }
     optional DockerSpec docker = 11;
 

--- a/jobs/src/main/scala/dcos/metronome/model/Container.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/Container.scala
@@ -1,6 +1,17 @@
 package dcos.metronome.model
 
+import mesosphere.marathon.state.Parameter
+import scala.collection.immutable.Seq
+
 trait Container
 
-case class DockerSpec(image: String, forcePullImage: Boolean = false) extends Container
+case class DockerSpec(
+  image:          String,
+  privileged:     Boolean        = false,
+  parameters:     Seq[Parameter] = Nil,
+  forcePullImage: Boolean        = false
+) extends Container
 
+object DockerSpec {
+  val DefaultParameters = Seq.empty[Parameter]
+}

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -71,7 +71,9 @@ object MarathonImplicits {
         case Some(dockerSpec) => Some(Container.Docker(
           image = dockerSpec.image,
           volumes = jobSpec.run.volumes.map(_.toMarathon),
-          forcePullImage = dockerSpec.forcePullImage
+          forcePullImage = dockerSpec.forcePullImage,
+          privileged = dockerSpec.privileged,
+          parameters = dockerSpec.parameters
         ))
         case _ => None
       }

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -16,14 +16,15 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedTaskInfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.TaskTracker
-import mesosphere.marathon.state.{ RunSpec, Timestamp }
+import mesosphere.marathon.state.{ Parameter, RunSpec, Timestamp }
 import org.apache.mesos.SchedulerDriver
 import org.apache.mesos
 import org.joda.time.DateTime
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, GivenWhenThen, Matchers }
 
-import scala.concurrent.Promise
+import scala.collection.immutable.Seq
+import scala.concurrent.{ Promise, duration }
 import scala.concurrent.duration._
 
 class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))


### PR DESCRIPTION
Allow Docker Params for Job Runs BP

Summary:
Need the ability to add or remove runtime capabilities to a docker container.

JIRA issues: DCOS_OSS-2564
https://jira.mesosphere.com/browse/DCOS_OSS-2564