### PR TITLE
Allow Docker Params for Job Runs Master

### DIFF
--- a/api/src/main/resources/public/api/v0/examples/job.json
+++ b/api/src/main/resources/public/api/v0/examples/job.json
@@ -27,7 +27,8 @@
     "mem": 32,
     "disk": 128,
     "docker": {
-      "image": "foo/bla:test"
+      "image": "foo/bla:test",
+      "privileged": true
     },
     "env": {
       "MON": "test",

--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -90,6 +90,27 @@
             "forcePullImage": {
               "type": "boolean",
               "documentation": "The containerizer will pull the image from the registry, even if the image is already downloaded on the agent node."
+            },
+            "privileged": {
+              "type": "boolean",
+              "documentation": "Run this docker image in privileged mode"
+            },
+            "parameters": {
+              "type": "array",
+              "description": "",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["key", "value"]
+              }
             }
           },
           "required": ["image"]

--- a/api/src/main/resources/public/api/v1/examples/job_docker_param.json
+++ b/api/src/main/resources/public/api/v1/examples/job_docker_param.json
@@ -1,0 +1,22 @@
+{
+  "description": "example docker parameters job",
+  "id": "docker-param",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "parameters": [
+        {
+          "key": "cap-drop",
+          "value": "ALL"
+        },
+        {
+          "key": "cap-add",
+          "value": "SYSLOG"
+        }
+      ]
+    }
+  }
+}

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -91,6 +91,27 @@
             "forcePullImage": {
               "type": "boolean",
               "documentation": "The containerizer will pull the image from the registry, even if the image is already downloaded on the agent."
+            },
+            "privileged": {
+              "type": "boolean",
+              "documentation": "Run this docker image in privileged mode"
+            },
+            "parameters": {
+              "type": "array",
+              "description": "",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["key", "value"]
+              }
             }
           },
           "required": ["image"]

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -12,7 +12,8 @@ import dcos.metronome.model._
 import dcos.metronome.scheduler.TaskState
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.plugin.PathId
-import mesosphere.marathon.state.{ RunSpec, Timestamp }
+import mesosphere.marathon.state.{ Parameter, Timestamp }
+import org.joda.time.{ DateTime, DateTimeZone }
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads._
 import play.api.libs.json.{ Json, _ }
@@ -134,7 +135,20 @@ package object models {
 
   implicit lazy val DockerSpecFormat: Format[DockerSpec] = (
     (__ \ "image").format[String] ~
+    (__ \ "privileged").formatNullable[Boolean].withDefault(false) ~
+    (__ \ "parameters").formatNullable[Seq[Parameter]].withDefault(DockerSpec.DefaultParameters) ~
     (__ \ "forcePullImage").formatNullable[Boolean].withDefault(false)) (DockerSpec.apply, unlift(DockerSpec.unapply))
+
+  implicit lazy val ParameterWrites: Writes[mesosphere.marathon.state.Parameter] = new Writes[mesosphere.marathon.state.Parameter] {
+    override def writes(param: mesosphere.marathon.state.Parameter): JsValue = Json.obj(
+      "key" -> param.key,
+      "value" -> param.value)
+  }
+
+  val ParameterReads: Reads[Parameter] = ((JsPath \ "key").read[String] and
+    (JsPath \ "value").read[String])((k, v) => mesosphere.marathon.state.Parameter(k, v))
+
+  implicit lazy val ParameterFormat: Format[mesosphere.marathon.state.Parameter] = Format(ParameterReads, ParameterWrites)
 
   implicit lazy val RestartSpecFormat: Format[RestartSpec] = (
     (__ \ "policy").formatNullable[RestartPolicy].withDefault(RestartSpec.DefaultRestartPolicy) ~

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -4,11 +4,11 @@ title: Docker Run Configurations
 
 # Docker
 
-It is possible now to run jobs using docker's privilege mode and/or using docker run time parameters.  These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+It is now possible to run jobs using Docker's privilege mode and/or using Docker runtime parameters. These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
 
 ## Privileged Mode
 
-Running docker in privileged mode is possible by setting `privileged=true` in the docker section of the job definition.
+Running Docker container in privileged mode is possible by setting `privileged: true` in the Docker section of the job definition.
 
 ```
 {
@@ -28,7 +28,7 @@ Running docker in privileged mode is possible by setting `privileged=true` in th
 
 ## Docker Parameters
 
-It is possible to set docker parameters now with job runs.   This enables the ability to change runtime capabilities of the job.   The example below removes all the default docker capabilities and adds SYSLOG.
+It is possible to set Docker parameters now with job runs. This makes it possible to change runtime capabilities of the job. The example below removes all the default docker capabilities and adds SYSLOG.
 
 ```
 {

--- a/docs/docs/docker.md
+++ b/docs/docs/docker.md
@@ -1,0 +1,56 @@
+---
+title: Docker Run Configurations
+---
+
+# Docker
+
+It is possible now to run jobs using docker's privilege mode and/or using docker run time parameters.  These can be used to control the [docker runtime privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+
+## Privileged Mode
+
+Running docker in privileged mode is possible by setting `privileged=true` in the docker section of the job definition.
+
+```
+{
+  "description": "example docker that runs in privilege mode",
+  "id": "docker-priv",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "privileged": true
+    }
+  }
+}
+```
+
+## Docker Parameters
+
+It is possible to set docker parameters now with job runs.   This enables the ability to change runtime capabilities of the job.   The example below removes all the default docker capabilities and adds SYSLOG.
+
+```
+{
+  "description": "example docker that changes runtime capabilities",
+  "id": "docker-param",
+  "run": {
+    "cmd": "sleep inf",
+    "cpus": 0.2,
+    "mem": 32,
+    "docker": {
+      "image": "ubuntu",
+      "parameters": [
+        {
+          "key": "cap-drop",
+          "value": "ALL"
+        },
+        {
+          "key": "cap-add",
+          "value": "SYSLOG"
+        }
+      ]
+    }
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,5 +15,9 @@ Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.10
 ## Contributing
 Learn how to [contribute to the Metronome project]({{ site.baseurl }}/docs/contributing.html).
 
+## Controlling Docker Runtime Capabilities
+Learn how to [change dockers runtime capabilities]({{ site.baseurl }}/docs/docker.html).
+
+
 ## API Reference
 Use the [Metronome REST API]({{ site.baseurl }}/docs/generated/api.html)

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,14 +10,13 @@ title: Cron Service for DC/OS
 </div>
 
 ## Documentation
-Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.10/deploying-jobs/).
+Metronome documentation lives on the [DC/OS docs site](https://dcos.io/docs/1.11/deploying-jobs/).
 
 ## Contributing
 Learn how to [contribute to the Metronome project]({{ site.baseurl }}/docs/contributing.html).
 
 ## Controlling Docker Runtime Capabilities
-Learn how to [change dockers runtime capabilities]({{ site.baseurl }}/docs/docker.html).
-
+Learn how to [change docker runtime capabilities]({{ site.baseurl }}/docs/docker.html).
 
 ## API Reference
 Use the [Metronome REST API]({{ site.baseurl }}/docs/generated/api.html)

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -13,6 +13,14 @@ message Label {
   optional string value = 2;
 }
 
+/**
+ * A generic (key, value) pair used in various places for parameters.
+ */
+message Parameter {
+  required string key = 1;
+  required string value = 2;
+}
+
 message JobHistory {
   optional string job_spec_id = 1;
   optional int64 success_count = 2;
@@ -149,6 +157,9 @@ message JobSpec {
       // is already downloaded on the agent.
       optional bool force_pull_image = 2;
 
+      optional bool privileged = 3 [default = false];
+
+      repeated Parameter parameters = 4;
     }
     optional DockerSpec docker = 11;
 

--- a/jobs/src/main/scala/dcos/metronome/model/Container.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/Container.scala
@@ -1,6 +1,17 @@
 package dcos.metronome
 package model
 
+import mesosphere.marathon.state.Parameter
+import scala.collection.immutable.Seq
+
 trait Container
 
-case class DockerSpec(image: String, forcePullImage: Boolean = false) extends Container
+case class DockerSpec(
+  image:          String,
+  privileged:     Boolean        = false,
+  parameters:     Seq[Parameter] = Nil,
+  forcePullImage: Boolean        = false) extends Container
+
+object DockerSpec {
+  val DefaultParameters = Seq.empty[Parameter]
+}

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -5,9 +5,11 @@ import java.time.ZoneId
 
 import dcos.metronome.model._
 import dcos.metronome.repository.impl.kv.EntityMarshaller
+import mesosphere.marathon.state.Parameter
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
 import scala.collection.mutable
 
 object JobSpecMarshaller extends EntityMarshaller[JobSpec] {
@@ -268,14 +270,38 @@ object RunSpecConversions {
     }.toList
   }
 
-  implicit class DockerSpecToProto(val dockerSpec: DockerSpec) extends AnyVal {
-    def toProto: Protos.JobSpec.RunSpec.DockerSpec = {
-      Protos.JobSpec.RunSpec.DockerSpec.newBuilder().setImage(dockerSpec.image).setForcePullImage(dockerSpec.forcePullImage).build()
+  implicit class ParametersToProto(val parameters: Seq[Parameter]) extends AnyVal {
+    def toProto: Iterable[Protos.Parameter] = parameters.map { parameter =>
+      val builder = Protos.Parameter.newBuilder
+      builder.setKey(parameter.key).setValue(parameter.value).build()
     }
   }
 
+  implicit class DockerSpecToProto(val dockerSpec: DockerSpec) extends AnyVal {
+    def toProto: Protos.JobSpec.RunSpec.DockerSpec = {
+      Protos.JobSpec.RunSpec.DockerSpec.newBuilder()
+        .setImage(dockerSpec.image)
+        .setForcePullImage(dockerSpec.forcePullImage)
+        .setPrivileged(dockerSpec.privileged)
+        .addAllParameters(dockerSpec.parameters.toProto.asJava)
+        .build()
+    }
+  }
+
+  implicit class ProtoToParameters(val parameters: mutable.Buffer[Protos.Parameter]) extends AnyVal {
+    def toModel: Seq[Parameter] = parameters.map { parameter =>
+      Parameter(
+        key = parameter.getKey,
+        value = parameter.getValue)
+    }.toList
+  }
+
   implicit class ProtoToDockerSpec(val dockerSpec: Protos.JobSpec.RunSpec.DockerSpec) extends AnyVal {
-    def toModel: DockerSpec = DockerSpec(image = dockerSpec.getImage, forcePullImage = dockerSpec.getForcePullImage)
+    def toModel: DockerSpec = DockerSpec(
+      image = dockerSpec.getImage,
+      forcePullImage = dockerSpec.getForcePullImage,
+      privileged = dockerSpec.getPrivileged,
+      parameters = dockerSpec.getParametersList.asScala.toModel)
   }
 
   implicit class EnvironmentToProto(val environment: Map[String, EnvVarValueOrSecret]) extends AnyVal {

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -66,7 +66,9 @@ object MarathonImplicits {
         case Some(dockerSpec) => Some(Container.Docker(
           image = dockerSpec.image,
           volumes = jobSpec.run.volumes.map(_.toMarathon),
-          forcePullImage = dockerSpec.forcePullImage))
+          forcePullImage = dockerSpec.forcePullImage,
+          privileged = dockerSpec.privileged,
+          parameters = dockerSpec.parameters))
         case _ => None
       }
 

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -22,12 +22,13 @@ import mesosphere.marathon.core.launchqueue.LaunchQueue.QueuedInstanceInfo
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.tracker.InstanceTracker
 import mesosphere.marathon.state.{ AppDefinition, RunSpec, Timestamp, UnreachableDisabled }
+import mesosphere.marathon.state._
 import org.apache.mesos.SchedulerDriver
 import org.apache.mesos
 import org.apache.zookeeper.KeeperException.NodeExistsException
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.time.{ Millis, Seconds, Span }
-import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, FunSuiteLike, GivenWhenThen, Matchers }
+import org.scalatest._
 
 import scala.concurrent.{ Future, Promise, duration }
 import scala.concurrent.duration._
@@ -502,7 +503,49 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     verify(f.launchQueue, atLeast(1)).add(argument.capture(), any)
     argument.getValue.container.get.docker.get.forcePullImage shouldBe true
   }
+  test("privileged is passed to Marathon when launching task") {
 
+    val f = new Fixture
+
+    Given("a jobRunSpec with forcePullImage")
+    val jobSpec = JobSpec(
+      id = JobId("/test"),
+      run = JobRunSpec(docker = Some(DockerSpec("image", privileged = true))))
+    val (_, jobRun) = f.setupInitialExecutorActor(Some(jobSpec))
+
+    And("a new task is launched")
+    val msg = f.persistenceActor.expectMsgType[JobRunPersistenceActor.Create]
+    msg.jobRun.status shouldBe JobRunStatus.Starting
+    f.persistenceActor.reply(JobRunPersistenceActor.JobRunCreated(f.persistenceActor.ref, jobRun, Unit))
+    import org.mockito.ArgumentCaptor
+    val argument: ArgumentCaptor[RunSpec] = ArgumentCaptor.forClass(classOf[RunSpec])
+
+    And("RunSpec is submitted to LaunchQueue with a Docker forcePullImage")
+    verify(f.launchQueue, atLeast(1)).add(argument.capture(), any)
+    argument.getValue.container.get.docker.get.privileged shouldBe true
+  }
+
+  test("docker parameters are passed to Marathon when launching task") {
+
+    val f = new Fixture
+
+    Given("a jobRunSpec with forcePullImage")
+    val jobSpec = JobSpec(
+      id = JobId("/test"),
+      run = JobRunSpec(docker = Some(DockerSpec("image", parameters = Seq(new Parameter("key", "value")).to[Seq]))))
+    val (_, jobRun) = f.setupInitialExecutorActor(Some(jobSpec))
+
+    And("a new task is launched")
+    val msg = f.persistenceActor.expectMsgType[JobRunPersistenceActor.Create]
+    msg.jobRun.status shouldBe JobRunStatus.Starting
+    f.persistenceActor.reply(JobRunPersistenceActor.JobRunCreated(f.persistenceActor.ref, jobRun, Unit))
+    import org.mockito.ArgumentCaptor
+    val argument: ArgumentCaptor[RunSpec] = ArgumentCaptor.forClass(classOf[RunSpec])
+
+    And("RunSpec is submitted to LaunchQueue with a Docker forcePullImage")
+    verify(f.launchQueue, atLeast(1)).add(argument.capture(), any)
+    argument.getValue.container.get.docker.get.parameters shouldBe jobSpec.run.docker.get.parameters
+  }
   test("aborts a job run if starting deadline is reached") {
     import scala.concurrent.duration._
     val f = new Fixture


### PR DESCRIPTION
Allow Docker Params for Job Runs Master

Summary:
Need the ability to add or remove runtime capabilities to a docker container.

This is the work that was on 0.4 that is being added to master for 0.5.x (eventually)

JIRA issues: DCOS_OSS-2564
https://jira.mesosphere.com/browse/DCOS_OSS-2564