### PR TITLE
Gracefully handle errors during task launching (#230)

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -8,11 +8,12 @@ import dcos.metronome.jobrun.StartedJobRun
 import dcos.metronome.model.{ JobResult, JobRun, JobRunId, JobRunStatus, JobRunTask, RestartPolicy }
 import dcos.metronome.scheduler.TaskState
 import dcos.metronome.utils.time.Clock
-import mesosphere.marathon.MarathonSchedulerDriverHolder
+import mesosphere.marathon.{ MarathonSchedulerDriverHolder, StoreCommandFailedException }
 import mesosphere.marathon.core.launchqueue.LaunchQueue
 import mesosphere.marathon.core.task.Task
 import mesosphere.marathon.core.task.Task.LaunchedEphemeral
 import mesosphere.marathon.core.task.tracker.TaskTracker
+import org.apache.zookeeper.KeeperException.NodeExistsException
 
 import scala.concurrent.Promise
 
@@ -83,10 +84,18 @@ class JobRunExecutorActor(
   }
 
   def addTaskToLaunchQueue(): Unit = {
-    log.info("addTaskToLaunchQueue")
-    import dcos.metronome.utils.glue.MarathonImplicits._
-    launchQueue.add(jobRun.toRunSpec, count = 1)
+    if (existsInLaunchQueue()) {
+      // we have to handle a case when actor is restarted (e.g. because of exception) and it already put something into the queue
+      // during restart it is possible, that actor that was in state Starting will be restarted with state initial
+      log.info(s"Job run ${jobRun.id} already exists in LaunchQueue - not adding")
+    } else {
+      log.info("addTaskToLaunchQueue")
+      import dcos.metronome.utils.glue.MarathonImplicits._
+      launchQueue.add(jobRun.toRunSpec, count = 1)
+    }
   }
+
+  def existsInLaunchQueue(): Boolean = launchQueue.get(runSpecId).exists(_.finalTaskCount > 0)
 
   def becomeActive(update: TaskStateChangedEvent): Unit = {
     jobRun = jobRun.copy(status = JobRunStatus.Active, tasks = updatedTasks(update))
@@ -217,6 +226,10 @@ class JobRunExecutorActor(
     receiveKill orElse {
       case JobRunCreated(_, updatedJobRun, _) =>
         becomeStarting(updatedJobRun)
+
+      case PersistFailed(_, id, ex, _) if ex.isInstanceOf[StoreCommandFailedException] && ex.getCause.isInstanceOf[NodeExistsException] =>
+        // we need to be able to handle restarted actor that already created the ZK node in the previous run
+        becomeStarting(jobRun.copy(status = JobRunStatus.Starting))
 
       case PersistFailed(_, id, ex, _) =>
         becomeAborting()


### PR DESCRIPTION
Backport: Gracefully handle errors during task launching

The cherry pick of the back port was not clean.   There are strong logical differences in the 0.4 branch.  This is the min needed to get the changes backported.   It is critical that an actor does not get caught in this dying loop.   Please be critical.

JIRA issues: DCOS-39102