### PR TITLE
Reduce log verbosity for known and expected conditions

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
+++ b/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
@@ -32,7 +32,8 @@ class ErrorHandler extends HttpErrorHandler {
       detected below and the verbose stacktrace is not logged.
      */
     if (exception.getMessage.contains("not an SSL/TLS record")) {
-      log.error(s"Error serving ${request.path} ${exception.getMessage}")
+      log.info(s"Client trying to connect via TLS port, but the proxying only happen through plain HTTP port. " +
+        s"Please use plain HTTP or query the leader directly. Error serving ${request.path}.  Exception Msg: ${exception.getMessage}")
     } else {
       log.error(s"Error serving ${request.path}", exception)
     }

--- a/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
+++ b/api/src/main/scala/dcos/metronome/api/ErrorHandler.scala
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory
 import play.api.http.HttpErrorHandler
 import play.api.http.Status._
 import play.api.libs.json.Json
-import play.api.mvc.{RequestHeader, Result, Results}
+import play.api.mvc.{ RequestHeader, Result, Results }
 import play.twirl.api.HtmlFormat
 
 import scala.concurrent.Future


### PR DESCRIPTION
Reduce log verbosity for known and expected conditions

Summary:
When a non-leading metronome is connected to by a client via the TLS port (9443 by default) and the leading master registers with the plain http port, the proxy tries to redirect a TLS connection to the plain http port. This results in the error which is expected and can be verbose in the logs.

The recommendation is to disable the plain HTTP port and always use TLS in this situation.   This PR detects the condition and reduces the logs.

https://jira.mesosphere.com/browse/MARATHON-7282

JIRA issues:MARATHON-7282
