### PR TITLE
Explicitly use new Caffeine dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -166,11 +166,12 @@ lazy val jobs = (project in file("jobs"))
       Dependencies.akka,
       Dependencies.twitterCommons,
       Dependencies.twitterZk,
+      Dependencies.caffeine,
       Dependencies.Test.scalatest,
       Dependencies.Test.akkaTestKit,
       Dependencies.Test.mockito,
       Dependencies.Test.scalatest,
-      Dependencies.Test.scalaCheck
+      Dependencies.Test.scalaCheck,
     ).map(
       _.excludeAll(excludeSlf4jLog4j12)
         .excludeAll(excludeLog4j)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Dependencies {
     val JsonValidate = "0.9.4"
     val TwitterCommons = "0.0.76"
     val TwitterZk = "6.40.0"
+    val Caffeine = "2.6.2"
   }
 
   val asyncAwait = "org.scala-lang.modules" %% "scala-async" % V.AsyncAwait
@@ -38,7 +39,8 @@ object Dependencies {
   val akka = "com.typesafe.akka" %%  "akka-actor" % V.Akka
   val jsonValidate = "com.eclipsesource" %% "play-json-schema-validator" % V.JsonValidate
   val twitterCommons = "com.twitter.common.zookeeper" % "candidate" % V.TwitterCommons
-  val twitterZk = "com.twitter" %% "util-zk" % V.TwitterZk
+  val twitterZk = "com.twitter" %% "util-zk" % V.TwitterZk exclude("com.github.ben-manes.caffeine", "caffeine")
+  val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % V.Caffeine // we need to override caffeine version because of dependency in dcos plugins
 
   object Test {
     val scalatest = "org.scalatest" %% "scalatest" % V.ScalaTest % "test"


### PR DESCRIPTION
We need this because dcos plugins depend on Caffeine 2.6.2 and we cannot just update the ZK utils because there is no build of that library with newer Caffeine.
