### PR TITLE
Add test for metronome config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,8 @@ lazy val metronome = (project in file("."))
     libraryDependencies ++= Seq(
       Dependencies.macWireMacros,
       Dependencies.macWireUtil,
-      Dependencies.macWireProxy
+      Dependencies.macWireProxy,
+      Dependencies.Test.scalatest
     )
   )
 

--- a/src/test/scala/dcos/metronome/MetronomeConfigTest.scala
+++ b/src/test/scala/dcos/metronome/MetronomeConfigTest.scala
@@ -1,0 +1,46 @@
+package dcos.metronome
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
+import play.api.Configuration
+
+class MetronomeConfigTest extends FunSuite with Matchers with GivenWhenThen {
+  private def fromConfig(cfg: String): MetronomeConfig =
+    new MetronomeConfig(new Configuration(ConfigFactory.parseString(cfg)))
+
+  test("Http and Https ports with valid parseable strings") {
+    Given("http Port is a valid port string")
+    val httpPort = "9000"
+    val httpsPort = "9010"
+
+    When("Config parser tries to extract it")
+    val cfg = fromConfig(
+      s"""
+         | play.server.http.port="$httpPort"
+         | play.server.https.port="$httpsPort"
+       """.stripMargin)
+
+    Then("Should return an integer of that given port")
+    cfg.httpPort shouldEqual Some(9000)
+    cfg.httpsPort shouldEqual 9010
+  }
+
+  test("Http overriden with `disabled`") {
+    Given("http Port is `disabled`")
+    val httpPort = "disabled"
+    val httpsPort = "9010"
+
+    When("Config parser tries to extract it")
+    val cfg = fromConfig(
+      s"""
+         | play.server.http.port="$httpPort"
+         | play.server.https.port="$httpsPort"
+       """.stripMargin)
+
+    Then("Http port should be None")
+    cfg.httpPort shouldEqual None
+
+    Then("Effective port should be https")
+    cfg.effectivePort shouldEqual 9010
+  }
+}


### PR DESCRIPTION
Add some tests for `MetronomeConfig` based on the issue occurred on https://github.com/dcos/metronome/commit/545acd030e34447d957ffcf01bd3fff336cb3fa9

I could not reproduce what the issue could have been so I appreciate if someone could guide into what the test should look like (i.e. what is the value in `play.server.http.port` that broke the config parsing.

I just saw that there is a suggested (Or required?) commit message pattern. I'll try to update my other PRs (and all from now on) to follow that pattern as well.

Thanks!