### PR TITLE
Turn on fatal warnings for compilation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val baseSettings = Seq(
     "-deprecation",
     "-feature",
     "-unchecked",
+    "-Xfatal-warnings",
     "-Xlog-reflective-calls",
     "-Xlint",
     "-Yno-adapted-args",


### PR DESCRIPTION
Since we have no more compilation warnings, I thought that it would be interesting to turn on fatal warnings feature in order to avoid having them in the first place.

Feel free to reject if you guys think it is not a good idea to add it