### PR TITLE
Turning on DC/OS 1.11 SI test

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -85,6 +85,22 @@ def get_private_ip():
             return agent
 
 
+def run_command_on_metronome_leader(
+    command,
+    username=None,
+    key_path=None,
+    noisy=True
+    ):
+    """ Run a command on the Metronome leader
+    """
+
+    return shakedown.run_command(metronome_leader_ip(), command, username, key_path, noisy)
+
+
+def metronome_leader_ip():
+    return shakedown.dcos_dns_lookup('metronome.mesos')[0]['ip']
+
+
 def constraints(name, operator, value=None):
     constraints = [name, operator]
     if value is not None:

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -265,7 +265,6 @@ def test_secret_env_var(secret_fixture):
         job_run_has_secret()
 
 
-@common.masters_exact(1)
 @shakedown.dcos_1_11
 def test_metronome_shutdown_with_no_extra_tasks():
     """ Test for METRONOME-100 regression
@@ -282,8 +281,7 @@ def test_metronome_shutdown_with_no_extra_tasks():
         # restart metronome process
         # this won't work in multi-master setup if the mesos leader is not the same as metronome leader
         # we can improve this one there is a good way how to get metronome leader from the system (e.g. info endpoint)
-        metronome_leader = shakedown.master_leader_ip()
-        shakedown.run_command_on_agent(metronome_leader, 'sudo systemctl restart dcos-metronome')
+        common.run_command_on_metronome_leader('sudo systemctl restart dcos-metronome')
         common.wait_for_metronome()
 
         # verify that no extra job runs were started when Metronome was restarted

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -15,6 +15,7 @@ from shakedown import dcos_version_less_than, marthon_version_less_than, require
 from dcos import metronome
 from retrying import retry
 
+# DC/OS 1.8 is when Metronome was added.  Skip prior clusters
 pytestmark = [pytest.mark.skipif("shakedown.dcos_version_less_than('1.8')")]
 
 
@@ -265,7 +266,7 @@ def test_secret_env_var(secret_fixture):
 
 
 @common.masters_exact(1)
-@pytest.mark.skip(reason="we need to wait until METRONOME-100 gets to testing/master")
+@shakedown.dcos_1_11
 def test_metronome_shutdown_with_no_extra_tasks():
     """ Test for METRONOME-100 regression
         When Metronome is restarted it incorrectly started another task for already running job run task.


### PR DESCRIPTION
Turning on DC/OS 1.11 SI test

Summary:
Providing context for skipping test on cluster earlier than 1.8.   Turning on test which should have been on already.

JIRA issues:
