### PR TITLE
Crash when Zookeeper connection fails to establish

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/JobsModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/JobsModule.scala
@@ -25,11 +25,11 @@ class JobsModule(
   private[this] lazy val pluginModule = new PluginModule(config.scallopConf, crashStrategy)
   def pluginManger: PluginManager = pluginModule.pluginManager
 
-  lazy val repositoryModule = new RepositoryModule(config)
+  val repositoryModule = new RepositoryModule(config)
 
-  lazy val actorsModule = new ActorsModule(actorSystem)
+  val actorsModule = new ActorsModule(actorSystem)
 
-  lazy val schedulerRepositoriesModule = new SchedulerRepositoriesModule(metricsModule.metrics, config, repositoryModule, lifecycleState, actorsModule, actorSystem)
+  val schedulerRepositoriesModule = new SchedulerRepositoriesModule(metricsModule.metrics, config, repositoryModule, lifecycleState, actorsModule, actorSystem)
 
   val schedulerModule: SchedulerModule = new SchedulerModule(
     metricsModule.metrics,


### PR DESCRIPTION
Previously, Metronome would become a zombie indefinitely if the initial
connection attempt to Zookeeper failed. Now, we crash if any exception is
thrown while initializing the Metronome JobApplicationLoader.

Additionally, we promote several more components to become eagerly initialized,
as opposed to lazy, in order to make it so our exception catch-all can catch
errors.

JIRA Issues: DCOS_OSS-4239
