### PR TITLE
No timeout for jenkins job

### DIFF
--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-timeout(120) {
+timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -1,6 +1,5 @@
 #!/usr/bin/env groovy
 
-timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
@@ -43,5 +42,4 @@ node('py36') {
     }
   }
   }
-}
 }

--- a/Jenkinsfile.open.si
+++ b/Jenkinsfile.open.si
@@ -6,16 +6,16 @@ node('py36') {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
 
     // Hardcoded default values are:
-    // DC/OS OS: channel="testing/pull/1739", for open cluster  (from: https://github.com/dcos/dcos/pull/1739)
-    // DC/OS EE: channel="testing/pull/1296", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/1296)
+    // DC/OS OS: channel="testing/pull/2359", for open cluster  (from: https://github.com/dcos/dcos/pull/2359)
+    // DC/OS EE: channel="testing/pull/2121", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/2121)
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // once a day between 1 AM and 5 AM
             pipelineTriggers([cron('H H(1-5) * * *')]),
             parameters([
                     string(name: 'channel',
-                            defaultValue: 'testing/pull/1739',
-                            description: 'PR to start the cluster from e.g. testing/pull/1739'
+                            defaultValue: 'testing/pull/2359',
+                            description: 'PR to start the cluster from e.g. testing/pull/2359'
                     )]
             )
     ])

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -6,16 +6,16 @@ node('py36') {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
 
     // Hardcoded default values are:
-    // DC/OS OS: channel="testing/pull/1739", for open cluster  (from: https://github.com/dcos/dcos/pull/1739)
-    // DC/OS EE: channel="testing/pull/1296", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/1296)
+    // DC/OS OS: channel="testing/pull/2359", for open cluster  (from: https://github.com/dcos/dcos/pull/2359)
+    // DC/OS EE: channel="testing/pull/2121", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/2121)
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // once a day between 1 AM and 5 AM
             pipelineTriggers([cron('H H(1-5) * * *')]),
             parameters([
                     string(name: 'channel',
-                            defaultValue: 'testing/pull/1296',
-                            description: 'PR to start the cluster from e.g. testing/pull/1296'
+                            defaultValue: 'testing/pull/2121',
+                            description: 'PR to start the cluster from e.g. testing/pull/2121'
                     )]
             )
     ])

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-timeout(120) {
+timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {

--- a/Jenkinsfile.permissive.si
+++ b/Jenkinsfile.permissive.si
@@ -1,6 +1,5 @@
 #!/usr/bin/env groovy
 
-timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
@@ -44,5 +43,4 @@ node('py36') {
     }
   }
   }
-}
 }

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -6,16 +6,16 @@ node('py36') {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
 
     // Hardcoded default values are:
-    // DC/OS OS: channel="testing/pull/1739", for open cluster  (from: https://github.com/dcos/dcos/pull/1739)
-    // DC/OS EE: channel="testing/pull/1296", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/1296)
+    // DC/OS OS: channel="testing/pull/2359", for open cluster  (from: https://github.com/dcos/dcos/pull/2359)
+    // DC/OS EE: channel="testing/pull/2121", for strict, permissive clusters  (from: https://github.com/mesosphere/dcos-enterprise/pull/2121)
     // The channel can be passed to the job in Jenkins (Build with Parameters) so that this job can be executed against any PR/cluster.
     properties([
             // once a day between 1 AM and 5 AM
             pipelineTriggers([cron('H H(1-5) * * *')]),
             parameters([
                     string(name: 'channel',
-                            defaultValue: 'testing/pull/1296',
-                            description: 'PR to start the cluster from e.g. testing/pull/1296'
+                            defaultValue: 'testing/pull/2121',
+                            description: 'PR to start the cluster from e.g. testing/pull/2121'
                     )]
             )
     ])

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-timeout(120) {
+timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {

--- a/Jenkinsfile.strict.si
+++ b/Jenkinsfile.strict.si
@@ -1,6 +1,5 @@
 #!/usr/bin/env groovy
 
-timeout(180) {
 node('py36') {
   wrap([$class: 'MesosSingleUseSlave']) {
   wrap([$class: 'AnsiColorBuildWrapper', 'colorMapName': 'XTerm']) {
@@ -44,5 +43,4 @@ node('py36') {
     }
   }
   }
-}
 }


### PR DESCRIPTION
Summary:
Right now we have two timeouts:
- one on the jenkins job level
- one on the pipeline level https://github.com/dcos/metronome/blob/master/ci/si_pipeline.sh#L79

The internal pipeline timeout is enough.

JIRA issues: MARATHON-8479
