### PR TITLE
Enable sbt-native-packager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,14 +18,6 @@ writeVersion := {
   s.log.info(s"Wrote version ${version.value} to ${file}")
 }
 
-/**
-  * The documentation for sbt-native-package can be foound here:	   * The documentation for sbt-native-package can be foound here:
-  * - General, non-vendor specific settings (such as launch script):	   * - General, non-vendor specific settings (such as launch script):
-  *     http://sbt-native-packager.readthedocs.io/en/latest/archetypes/java_app/index.html#usage	   *     http://sbt-native-packager.readthedocs.io/en/latest/archetypes/java_app/index.html#usage
-  *	   *
-  * - Linux packaging settings	   * - Linux packaging settings
-  *     http://sbt-native-packager.readthedocs.io/en/latest/archetypes/java_app/index.html#usage	   *     http://sbt-native-packager.readthedocs.io/en/latest/archetypes/java_app/index.html#usage
-  */
 lazy val packagingSettings = Seq(
   (packageName in Universal) := {
     import sys.process._
@@ -117,6 +109,7 @@ lazy val metronome = (project in file("."))
   .dependsOn(api, jobs)
   .aggregate(api, jobs)
   .enablePlugins(PlayScala)
+  .enablePlugins(JavaServerAppPackaging)
   .disablePlugins(PlayLayoutPlugin)
   .enablePlugins(UniversalDeployPlugin)
   .settings(projectSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,3 +25,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.6.3")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.9")

--- a/run.sh
+++ b/run.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 
 ZK_URL="${1:-zk://127.0.0.1:2181/metronome}"
-MESOS_MASTER_URL="${2:-127.0.0.1:5050}"
+MESOS_MASTER_URL="${2:-zk://127.0.0.1:2181/mesos}"
 HTTP_PORT="${3:-9000}"
 
-sbt universal:packageBin
-ZIP_COUNT=`ls target/universal/metronome*.zip | wc -l`
-if [ ${ZIP_COUNT} -gt 1 ]; then
-    echo "Multiple metronome zip files inside /target/universal. Run 'sbt clean' or remove one manually.".
-    exit 1
+if [ -z "$NOBUILD" ]; then
+  sbt stage
 fi
-# unpack the package
-unzip -o -d target/universal -a target/universal/metronome-*.zip
-chmod +x target/universal/metronome-*/bin/metronome
-LIBPROCESS_IP=127.0.0.1 ./target/universal/metronome-*/bin/metronome -d -v -Dmetronome.framework.name=metronome-dev -Dmetronome.zk.url=$ZK_URL -Dmetronome.mesos.master.url=$MESOS_MASTER_URL -Dplay.server.http.port=$HTTP_PORT
+LIBPROCESS_IP=127.0.0.1 ./target/universal/stage/bin/metronome -d -v -Dmetronome.framework.name=metronome-dev -Dmetronome.zk.url=$ZK_URL -Dmetronome.mesos.master.url=$MESOS_MASTER_URL -Dplay.server.http.port=$HTTP_PORT


### PR DESCRIPTION
This allows us to use native packager to run Metronome locally in dev mode;
it's far faster and more straightforward that the existing assembly + unzip
scripts.
