### PR TITLE
Replace EQ operator with IS

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -106,7 +106,7 @@ package object models {
   }
 
   implicit lazy val OperatorFormat: Format[Operator] = new Format[Operator] {
-    override def writes(o: Operator): JsValue = JsString(Operator.name(o))
+    override def writes(o: Operator): JsValue = JsString(o.name)
     override def reads(json: JsValue): JsResult[Operator] = json match {
       case JsString(Operator(value)) => JsSuccess(value)
       case invalid => JsError(s"'$invalid' is not a valid operator. " +

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,41 @@
+# Unreleased
+
+## In replaces Eq operator
+
+In order to bring better alignment between Marathon and Metronome, the Eq constraint operator has been replaced with In. The change is semantic; Job definitions using Eq will continue to function the same and are transparently mapped to the new operator with the same constraint behavior.
+
+If you post the following Job definition:
+
+```json
+{
+  "description": "constraint example",
+  "id": "constraint-example",
+  "run": {
+    ...
+    "placement": {
+      "constraints": [{"attribute": "@region", "operator": "EQ", "value": "us-east-1"}]
+    }
+  }
+}
+```
+
+When you ask for it back, the operator will be "IN":
+
+```json
+{
+  "description": "constraint example",
+  "id": "constraint-example",
+  "run": {
+    ...
+    "placement": {
+      "constraints": [{"attribute": "@region", "operator": "IN", "value": "us-east-1"}]
+    }
+  }
+}
+```
+
+Previous jobs are automatically migrated as well.
+
 # Version 0.5.3
 
 ## Bugs

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -131,6 +131,8 @@ message JobSpec {
           LIKE = 3;
           // Field must not match the regex given by value.
           UNLIKE = 4;
+          // Field must be the specified value
+          IS = 6;
         }
         optional Operator operator = 2;
         optional string value = 3;

--- a/jobs/src/main/scala/dcos/metronome/model/PlacementSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/PlacementSpec.scala
@@ -9,19 +9,18 @@ object PlacementSpec {
 
 case class ConstraintSpec(attribute: String, operator: Operator, value: Option[String])
 
-sealed trait Operator
+sealed trait Operator { val name: String }
 object Operator {
-  case object Eq extends Operator
-  case object Like extends Operator
-  case object Unlike extends Operator
+  case object Is extends Operator { val name = "IS" }
+  case object Like extends Operator { val name = "LIKE" }
+  case object Unlike extends Operator { val name = "UNLIKE" }
 
-  val names: Map[String, Operator] = Map(
-    "EQ" -> Eq,
-    "LIKE" -> Like,
-    "UNLIKE" -> Unlike)
-  val operatorNames: Map[Operator, String] = names.map{ case (a, b) => (b, a) }
-
-  def name(operator: Operator): String = operatorNames(operator)
+  val all = Seq(Is, Like, Unlike)
+  /**
+    * For backwards compatibility, we map EQ to Is
+    */
+  val names: Map[String, Operator] =
+    Map(all.map { op => op.name -> op }: _*) + ("EQ" -> Is)
   def unapply(name: String): Option[Operator] = names.get(name)
   def isDefined(name: String): Boolean = names.contains(name)
 }

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -234,19 +234,19 @@ object RunSpecConversions {
       builder
         .setAttribute(constraint.attribute)
         .setOperator(
-          Protos.JobSpec.RunSpec.PlacementSpec.Constraint.Operator.valueOf(Operator.name(constraint.operator)))
+          Protos.JobSpec.RunSpec.PlacementSpec.Constraint.Operator.valueOf(constraint.operator.name))
         .build()
     }
   }
 
-  implicit class ProtosToConstraintSpec(val constraints: mutable.Buffer[Protos.JobSpec.RunSpec.PlacementSpec.Constraint]) extends AnyVal {
+  implicit class ProtosToConstraintSpec(val constraints: Iterable[Protos.JobSpec.RunSpec.PlacementSpec.Constraint]) extends AnyVal {
     def toModel: Seq[ConstraintSpec] = constraints.map { constraint =>
       val value = if (constraint.hasValue) Some(constraint.getValue) else None
       ConstraintSpec(
         attribute = constraint.getAttribute,
         operator = Operator.names(constraint.getOperator.toString),
         value = value)
-    }.toList
+    }(collection.breakOut)
   }
 
   implicit class ArtifactsToProto(val artifacts: Seq[Artifact]) extends AnyVal {

--- a/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
+++ b/jobs/src/main/scala/dcos/metronome/utils/glue/MarathonImplicits.scala
@@ -43,8 +43,9 @@ object MarathonImplicits {
       /**
         * Unfortunately, Metronome has always allowed valueless constraint operators, but they never had any effect.
         *
-        * The Eq operator was replaced with Is in of favor consistency. Eq mapped to CLUSTER, and valueless cluster in
-        * the context of jobs made no sense.
+        * For the sake of consistency with Marathon, the Eq operator was replaced with Is. Previously, Eq mapped to
+        * CLUSTER, and valueless CLUSTER constraint (which has a specific meaning in Marathon) has no meaning in the
+        * context of jobs.
         *
         * Ideally, we would make the value required, but this would be an API breaking change.
         */

--- a/jobs/src/test/scala/dcos/metronome/model/PlacementSpecSpec.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/PlacementSpecSpec.scala
@@ -1,0 +1,10 @@
+package dcos.metronome.model
+
+import dcos.metronome.utils.test.Mockito
+import org.scalatest.{ FunSuite, Matchers }
+
+class PlacementSpecSpec extends FunSuite with Matchers {
+  test("Operator unapply converts EQ to IS") {
+    Operator.unapply("EQ").shouldEqual(Operator.Is)
+  }
+}

--- a/jobs/src/test/scala/dcos/metronome/model/PlacementSpecSpec.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/PlacementSpecSpec.scala
@@ -1,10 +1,9 @@
 package dcos.metronome.model
 
-import dcos.metronome.utils.test.Mockito
 import org.scalatest.{ FunSuite, Matchers }
 
 class PlacementSpecSpec extends FunSuite with Matchers {
   test("Operator unapply converts EQ to IS") {
-    Operator.unapply("EQ").shouldEqual(Operator.Is)
+    Operator.unapply("EQ").get.shouldEqual(Operator.Is)
   }
 }


### PR DESCRIPTION
We replace the EQ operator with IS to better match Marathon's constraint API. Change is done in a backwards compatible way such that:

* Posting an EQ constraint gets converted to an IS constraint, automatically
* Upgrading from a prior version of metronome with a JobSpec transparently converts to IS
* Valueless IS makes no sense (as does LIKE and UNLIKE) and continues to have no effect, as valueless EQ did.

JIRA Issues: DCOS_OSS-4464
