### PR TITLE
Fixing Release Build CI missing file

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -26,6 +26,7 @@ ansiColor('xterm') {
         ]) {
           sshagent (credentials: ['0f7ec9c9-99b2-4797-9ed5-625572d5931d']) {
             sh "bin/install-protobuf.sh"
+            sh "ci/ci_provision.sh"
             sh """PATH=\$PATH:\$HOME/protobuf/bin ci/pipeline release $params.version $params.gitsha"""
           }
         }


### PR DESCRIPTION
Fixing Release Build CI missing file

Summary:
fixing the missing upgrade.sc file for releases which included in our regular builds

JIRA issues:
