### PR TITLE
Better message when not enough agents

### DIFF
--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -327,7 +327,7 @@ def setup_module(module):
     common.wait_for_cosmos()
     agents = shakedown.get_private_agents()
     if len(agents) < 2:
-        assert False, "Incorrect Agent count"
+        assert False, f"Incorrect Agent count. Expecting at least 2 agents, but have {len(agents)}"
     remove_jobs()
 
 


### PR DESCRIPTION
I just improved the log message after seeing the tests failed because of not enough agents https://jenkins.mesosphere.com/service/jenkins/job/system-integration-tests/job/metronome-si-dcos-open/job/master/321/console
