### PR TITLE
Resolving timeout issues associated with Master bounce

### DIFF
--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -76,7 +76,7 @@ case $CLUSTER_LAUNCH_CODE in
   0)
       echo "marathon.build.$JOB_NAME_SANITIZED.cluster_launch.success"
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"
-      timeout --preserve-status -s KILL 2h make test
+      timeout --preserve-status -s KILL 1.5h make test
       SI_CODE=$?
       if [ ${SI_CODE} -gt 0 ]; then
         echo "marathon.build.$JOB_NAME_SANITIZED.failure"

--- a/ci/si_pipeline.sh
+++ b/ci/si_pipeline.sh
@@ -39,7 +39,7 @@ function exit-with-cluster-launch-error {
     echo "$1"
     create-junit-xml "dcos-launch" "cluster.create" "$1"
     pipenv run dcos-launch -i "$INFO_PATH" delete
-    "$ROOT_PATH/ci/dataDogClient.sc" "marathon.build.$JOB_NAME_SANITIZED.cluster_launch.failure" 1
+    echo "metronome.build.$JOB_NAME_SANITIZED.cluster_launch.failure"
     exit 0
 }
 
@@ -74,15 +74,15 @@ CLUSTER_LAUNCH_CODE=$?
 export DCOS_URL
 case $CLUSTER_LAUNCH_CODE in
   0)
-      "$ROOT_PATH/ci/dataDogClient.sc" "marathon.build.$JOB_NAME_SANITIZED.cluster_launch.success" 1
+      echo "marathon.build.$JOB_NAME_SANITIZED.cluster_launch.success"
       cp -f "$DOT_SHAKEDOWN" "$HOME/.shakedown"
       timeout --preserve-status -s KILL 2h make test
       SI_CODE=$?
       if [ ${SI_CODE} -gt 0 ]; then
-        "$ROOT_PATH/ci/dataDogClient.sc" "marathon.build.$JOB_NAME_SANITIZED.failure" 1
+        echo "marathon.build.$JOB_NAME_SANITIZED.failure"
         download-diagnostics-bundle
       else
-        "$ROOT_PATH/ci/dataDogClient.sc" "marathon.build.$JOB_NAME_SANITIZED.success" 1
+        echo "marathon.build.$JOB_NAME_SANITIZED.success"
       fi
       pipenv run dcos-launch -i "$INFO_PATH" delete || true
       exit "$SI_CODE" # Propagate return code.

--- a/tests/system/Makefile
+++ b/tests/system/Makefile
@@ -28,7 +28,7 @@ test:
       --stdout all \
       --stdout-inline \
       --ssl-no-verify \
-      --timeout 360000 \
+      --timeout 1800 \
       --pytest-option "--junitxml=../../shakedown.xml" \
       --pytest-option --verbose \
       --pytest-option --full-trace \

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -128,6 +128,7 @@ def test_disable_schedule_recovery_from_master_bounce():
 
         # bounce metronome master
         common.run_command_on_metronome_leader('sudo /sbin/shutdown -r now')
+        common.wait_for_cosmos()
         common.wait_for_metronome()
 
         # wait for the next run


### PR DESCRIPTION
Resolving timeout issues associated with Master bounce

Summary:
decrease timeout for each test.  remove reference to missing code from copy and paste mistake

total test timeout is changed from 2 hours to 1.5 hours.  This is to ensure that the cluster is still up after the timeout and before the cluster is destroyed... so we can get diag bundles.

JIRA issues:  DCOS_OSS-4536
