### PR TITLE
skip 0.6.0 feature until after 0.6.0 is released

### DIFF
--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -242,6 +242,7 @@ def test_docker_job():
         time.sleep(2)
         assert len(client.get_runs(job_id)) == 1
 
+
 @metronone_0_6_0
 def test_ucr_job():
     client = metronome.create_client()

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -242,7 +242,7 @@ def test_docker_job():
         time.sleep(2)
         assert len(client.get_runs(job_id)) == 1
 
-
+@metronone_0_6_0
 def test_ucr_job():
     client = metronome.create_client()
     job_id = uuid.uuid4().hex


### PR DESCRIPTION
skip 0.6.0 feature until after 0.6.0 is released

Summary:
skip 0.6.0 feature until after 0.6.0 is released

JIRA issues:
