### PR TITLE
we can not install ee without the cosmos

### DIFF
--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -349,6 +349,7 @@ def job(job_json):
 
 @pytest.fixture(scope="function")
 def secret_fixture():
+    common.wait_for_cosmos()
     if not common.is_enterprise_cli_package_installed():
         common.install_enterprise_cli_package()
 


### PR DESCRIPTION
we can not install ee without the cosmos

Summary:
we can not install ee without the cosmos

JIRA issues:  DCOS_OSS-4369
