### PR TITLE
Making FBS work from v1 and working SI

### DIFF
--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -250,8 +250,7 @@
               "containerPath": {
                 "type": "string",
                 "description": "The path of the volume in the container",
-                "minLength": 1,
-                "pattern": "^/[^/].*$"
+                "minLength": 1
               },
               "hostPath": {
                 "type": "string",

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -59,6 +59,7 @@ def job_with_file_based_secret(
         id='pikachu-fbs',
         cmd='cat $MESOS_SANDBOX/secret-file > $MESOS_SANDBOX/fbs-secret; sleep 30',
         secret_name='secret_name'):
+    # secret container path can not have '/' prefix for secret, otherwise needs it
     return {
         'id': id,
         'description': 'electrifying rodent',

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -57,7 +57,7 @@ def job_with_secrets(id='pikachu',
 
 def job_with_file_based_secret(
         id='pikachu-fbs',
-        cmd='cat $MESOS_SANDBOX/secret-file > $MESOS_SANDBOX/fbs-secret; sleep 5',
+        cmd='cat $MESOS_SANDBOX/secret-file > $MESOS_SANDBOX/fbs-secret; sleep 30',
         secret_name='secret_name'):
     return {
         'id': id,
@@ -69,7 +69,7 @@ def job_with_file_based_secret(
             'disk': 0,
             "volumes": [
                 {
-                    "containerPath": "/secret-file",
+                    "containerPath": "secret-file",
                     "secret": "secret1"
                 }
             ],

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -73,15 +73,15 @@ def job_with_file_based_secret(
                     "secret": "secret1"
                 }
             ],
+            'ucr': {
+                "image": {
+                    "id": "busybox"
+                }
+            },
             "secrets": {
                 "secret1": {
                     "source": secret_name
                 }
-            }
-        },
-        'ucr': {
-            "image": {
-                "id": "busybox"
             }
         }
     }

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -289,7 +289,8 @@ def test_secret_file(secret_fixture):
     job_id = uuid.uuid4().hex
     job_def = common.job_with_file_based_secret(job_id, secret_name=secret_name)
     print(job_def)
-
+    # secret container path can not have '/' prefix for secret, otherwise needs it
+    # shakedown / dcos cli validates that '/' must be there :(
     with job(job_def):
         run_id = client.run_job(job_id)['id']
         common.wait_for_job_started(job_id, run_id, timeout=timedelta(minutes=5).total_seconds())

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -271,7 +271,7 @@ def test_secret_env_var(secret_fixture):
 
         @retry(wait_fixed=1000, stop_max_delay=5000)
         def job_run_has_secret():
-            stdout, stderr, return_code = shakedown.run_dcos_command("task log {} secret-env".format(run_id))
+            stdout, stderr, return_code = shakedown.run_dcos_command("task log --all {} secret-env".format(run_id))
             logged_secret = stdout.rstrip()
             assert secret_value == logged_secret, ("secret value in stdout log incorrect or missing. "
                                                    "'{}' should be '{}'").format(logged_secret, secret_value)
@@ -288,6 +288,7 @@ def test_secret_file(secret_fixture):
     client = metronome.create_client()
     job_id = uuid.uuid4().hex
     job_def = common.job_with_file_based_secret(job_id, secret_name=secret_name)
+    print(job_def)
 
     with job(job_def):
         run_id = client.run_job(job_id)['id']
@@ -295,7 +296,7 @@ def test_secret_file(secret_fixture):
 
         @retry(wait_fixed=1000, stop_max_delay=5000)
         def job_run_has_secret():
-            stdout, stderr, return_code = shakedown.run_dcos_command("task log {} fbs-secret".format(run_id))
+            stdout, stderr, return_code = shakedown.run_dcos_command("task log --all {} fbs-secret".format(run_id))
             logged_secret = stdout.rstrip()
             assert secret_value == logged_secret, ("secret value in stdout log incorrect or missing. "
                                                    "'{}' should be '{}'").format(logged_secret, secret_value)

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -288,9 +288,7 @@ def test_secret_file(secret_fixture):
     client = metronome.create_client()
     job_id = uuid.uuid4().hex
     job_def = common.job_with_file_based_secret(job_id, secret_name=secret_name)
-    print(job_def)
-    # secret container path can not have '/' prefix for secret, otherwise needs it
-    # shakedown / dcos cli validates that '/' must be there :(
+
     with job(job_def):
         run_id = client.run_job(job_id)['id']
         common.wait_for_job_started(job_id, run_id, timeout=timedelta(minutes=5).total_seconds())


### PR DESCRIPTION
Making FBS work from v1 and working SI

Summary:
Testing FBS from v1 was failing.   It required a `/` for a containerpath. which breaks secrets for some reason.    I was able to test this from v0 which doesn't have this restriction.   The SI tests were broken as well and have been modified to be less flaky.


JIRA issues:
