### PR TITLE
Test Mesos Not AWS for Master Bounce

### DIFF
--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -11,7 +11,7 @@ import pytest
 
 from distutils.version import LooseVersion
 
-from dcos import metronome, packagemanager, cosmos
+from dcos import metronome, packagemanager, cosmos, http
 from dcos.errors import DCOSException
 from json.decoder import JSONDecodeError
 from retrying import retry
@@ -348,3 +348,24 @@ def create_secret(name, value=None, description=None):
         description_opt,
         name), print_output=True)
     assert return_code == 0, "Failed to create a secret"
+
+
+def get_metronome_endpoint(path, metronome_name='metronome'):
+    """Returns the url for the metronome endpoint."""
+    return shakedown.dcos_url_path('service/{}/{}'.format(metronome_name, path))
+
+
+def metronome_version():
+    """Returns the JSON of verison information for Metronome.
+    """
+    response = http.get(get_metronome_endpoint('info'))
+    return response.json()
+
+
+def cluster_info():
+    print("DC/OS: {}, in {} mode".format(shakedown.dcos_version(), shakedown.ee_version()))
+    agents = shakedown.get_private_agents()
+    print("Agents: {}".format(len(agents)))
+
+    about = metronome_version()
+    print("Marathon version: {}".format(about))

--- a/tests/system/common.py
+++ b/tests/system/common.py
@@ -1,7 +1,6 @@
 """ Commons for Metronome """
 
 from datetime import timedelta
-from dcos import http
 
 import json
 import shakedown

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -126,7 +126,7 @@ def test_disable_schedule_recovery_from_master_bounce():
         job_schedule['enabled'] = False
         client.update_schedule(job_id, 'nightly', job_schedule)
 
-        # bounce metronome master
+        # bounce mesos master
         shakedown.run_command_on_leader('sudo systemctl restart dcos-mesos-master')
         common.wait_for_cosmos()
         common.wait_for_metronome()

--- a/tests/system/test_root_metronome.py
+++ b/tests/system/test_root_metronome.py
@@ -127,7 +127,7 @@ def test_disable_schedule_recovery_from_master_bounce():
         client.update_schedule(job_id, 'nightly', job_schedule)
 
         # bounce metronome master
-        common.run_command_on_metronome_leader('sudo /sbin/shutdown -r now')
+        shakedown.run_command_on_leader('sudo systemctl restart dcos-mesos-master')
         common.wait_for_cosmos()
         common.wait_for_metronome()
 
@@ -327,6 +327,7 @@ def test_metronome_shutdown_with_no_extra_tasks():
 def setup_module(module):
     common.wait_for_metronome()
     common.wait_for_cosmos()
+    common.cluster_info()
     agents = shakedown.get_private_agents()
     if len(agents) < 2:
         assert False, f"Incorrect Agent count. Expecting at least 2 agents, but have {len(agents)}"


### PR DESCRIPTION
Test Mesos Not AWS for Master Bounce

Summary:
do not restart node, just restart the master agent. also lets provide cluster info for test which includes version.

JIRA issues:
