### PR TITLE
Do not dump whole config when starting metronome BP

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,7 +32,7 @@ akka {
   #
   # And then uncomment this line to debug the configuration.
   #
-  log-config-on-start = true
+  log-config-on-start = false
 
   actor {
     default-dispatcher {


### PR DESCRIPTION
Do not dump whole config when starting metronome 

Summary:
Backport of #310 

JIRA issues:
