### PR TITLE
GPU is valid for cmd only.  It is invalid only for Docker.

### DIFF
--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -210,7 +210,19 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       Then("The job is created")
       status(response) mustBe UNPROCESSABLE_ENTITY
       contentType(response) mustBe Some("application/json")
-      contentAsString(response).contains("GPUs are only supported by UCR") mustBe true
+      contentAsString(response).contains("GPUs are not supported with Docker") mustBe true
+    }
+
+    "creates a job sending a valid job with cmd and no docker or ucr container" in {
+      Given("No job")
+
+      When("A job with CMD with gpus is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(cmdGpuJobJson)).get
+
+      Then("The job is created")
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+      contentAsJson(response) mustBe cmdGpuJobJson
     }
 
     "create a job with secrets" in {
@@ -548,6 +560,7 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
 
   def spec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds), docker = Some(DockerSpec("image", forcePullImage = true))))
   def ucrSpec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds), ucr = Some(UcrSpec(ImageSpec(id = "image", forcePull = true)))))
+  def cmdSpec(id: String) = JobSpec(JobId(id), run = JobRunSpec(taskKillGracePeriodSeconds = Some(10 seconds), cmd = Some("sleep")))
   val CronSpec(cron) = "* * * * *"
   val schedule1 = ScheduleSpec("id1", cron)
   val jobSpec1 = spec("spec1")
@@ -602,6 +615,12 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
   }
   val dockerGpuJobJson = Json.toJson(dockerGpuJob)
   val auth = new TestAuthFixture
+
+  val cmdGpuJob = {
+    val s = cmdSpec("cmd-gpu")
+    s.copy(run = s.run.copy(gpus = 4))
+  }
+  val cmdGpuJobJson = Json.toJson(cmdGpuJob)
 
   before {
     auth.authorized = true

--- a/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRunSpec.scala
@@ -73,7 +73,7 @@ object JobRunSpec {
       def noSecretVolumesExists: Boolean = jobRunSpec.volumes.forall(v => !isSecretVolume(v))
       check(noSecretVolumesExists || jobRunSpec.ucr.isDefined, JobRunSpecMessages.fileBasedSecretsAreUcrOnly)
 
-      check(jobRunSpec.gpus == 0 || jobRunSpec.ucr.isDefined, JobRunSpecMessages.gpusAreUcrOnly)
+      check(jobRunSpec.gpus == 0 || jobRunSpec.docker.isEmpty, JobRunSpecMessages.gpusNotValidWithDocker)
 
       violations.headOption.getOrElse(Success)
     }
@@ -87,5 +87,5 @@ object JobRunSpecMessages {
   }
   val onlyDockerOrUcr = "Either Docker or UCR should be provided, but not both"
   val fileBasedSecretsAreUcrOnly = "File based secrets are only supported by UCR"
-  val gpusAreUcrOnly = "GPUs are only supported by UCR"
+  val gpusNotValidWithDocker = "GPUs are not supported with Docker"
 }


### PR DESCRIPTION

Summary:
Metronome was previously written to reject jobs with GPU if UCR isn't defined which is NOT correct.   It should reject if Docker is defined.   If there is no container defined it is technically UCR by default (or Mesos containerizer).   This change now rejects jobs if GPU is requested AND docker is defined.

JIRA issues:  DCOS_OSS-4934
