### PR TITLE
Adjust schemas to allow IS as a valid placement constraint operator.

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -200,7 +200,7 @@
                   "operator": {
                     "type": "string",
                     "description": "The operator for this constraint.",
-                    "enum": ["EQ", "LIKE", "UNLIKE"]
+                    "enum": ["IS", "EQ", "LIKE", "UNLIKE"]
                   },
                   "value": {
                     "type": "string",

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -202,7 +202,7 @@
                   "operator": {
                     "type": "string",
                     "description": "The operator for this constraint.",
-                    "enum": ["EQ", "LIKE", "UNLIKE"]
+                    "enum": ["IS", "EQ", "LIKE", "UNLIKE"]
                   },
                   "value": {
                     "type": "string",

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 0.6.12
+
+## Bug fixes
+* [DCOS_OSS-4978](https://jira.mesosphere.com/browse/DCOS_OSS-4978) Allow using `IS` operator when creating jobs. This was broken since introduction of the `IS` operator, which replaced `EQ` but was not a valid schema value. 
+
 # 0.6.11
 
 Updated Marathon dependency to 1.7.202
@@ -15,9 +20,9 @@ This brings a lot of bug fixes and new features from the last 3 versions of Mara
 
 Metronome 0.5.71 contains new Metrics endpoint with new metrics exposed that should allow you to monitor Metronome more easily. For detailed information please refer to the Metrics page in our docs.
 
-## In replaces Eq operator
+## IS replaces EQ operator
 
-In order to bring better alignment between Marathon and Metronome, the Eq constraint operator has been replaced with In. The change is semantic; Job definitions using Eq will continue to function the same and are transparently mapped to the new operator with the same constraint behavior.
+In order to bring better alignment between Marathon and Metronome, the `EQ` constraint operator has been replaced with `IS`. The change is semantic; Job definitions using `EQ` will continue to function the same and are transparently mapped to the new operator with the same constraint behavior.
 
 If you post the following Job definition:
 
@@ -34,7 +39,7 @@ If you post the following Job definition:
 }
 ```
 
-When you ask for it back, the operator will be "IN":
+When you ask for it back, the operator will be "IS":
 
 ```json
 {
@@ -43,7 +48,7 @@ When you ask for it back, the operator will be "IN":
   "run": {
     ...
     "placement": {
-      "constraints": [{"attribute": "@region", "operator": "IN", "value": "us-east-1"}]
+      "constraints": [{"attribute": "@region", "operator": "IS", "value": "us-east-1"}]
     }
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/model/PlacementSpecTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/PlacementSpecTest.scala
@@ -2,8 +2,11 @@ package dcos.metronome.model
 
 import org.scalatest.{ FunSuite, Matchers }
 
-class PlacementSpecSpec extends FunSuite with Matchers {
+class PlacementSpecTest extends FunSuite with Matchers {
   test("Operator unapply converts EQ to IS") {
     Operator.unapply("EQ").get.shouldEqual(Operator.Is)
+  }
+  test("Operator unapply IS") {
+    Operator.unapply("IS").get.shouldEqual(Operator.Is)
   }
 }


### PR DESCRIPTION
Summary:
DCOS_OSS-4464 introduced the IS operator as a replacement for EQ via #287. Even though a conversion was added from EQ to IS, we missed to add IS to the enumeration for placement constraint operators. This commit adjusts the schemas for v0 and v1 accordingly.

JIRA issues: DCOS_OSS-4978