### PR TITLE
Fixing the ability to have a failed job have a retry

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 0.6.NEXT
+* [DCOS_OSS-4636](https://jira.mesosphere.com/browse/DCOS_OSS-4636) Failure when restart policy is `ON_FAILURE`.  This bug was introduced through the fix of another bug regarding stopping invalid extra instances of a job run.  Metronome should not check the launch queue when a restart is invoked.
+
 # 0.6.12
 
 ## Bug fixes


### PR DESCRIPTION

Summary:
Previous bug fix introduced this bug which prevented metronome from restarting a failed job run.

JIRA issues:  DCOS_OSS-4636
