### PR TITLE
Adjust schemas to allow IS as a valid placement constraint operator. *Back Port*

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -200,7 +200,7 @@
                   "operator": {
                     "type": "string",
                     "description": "The operator for this constraint.",
-                    "enum": ["EQ", "LIKE", "UNLIKE"]
+                    "enum": ["IS", "EQ", "LIKE", "UNLIKE"]
                   },
                   "value": {
                     "type": "string",

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -202,7 +202,7 @@
                   "operator": {
                     "type": "string",
                     "description": "The operator for this constraint.",
-                    "enum": ["EQ", "LIKE", "UNLIKE"]
+                    "enum": ["IS", "EQ", "LIKE", "UNLIKE"]
                   },
                   "value": {
                     "type": "string",

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -313,6 +313,114 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       contentType(response) mustBe Some("application/json")
       contentAsString(response).contains("expected HostVolume or SecretVolume") mustBe true
     }
+
+    "convert EQ and allow IS placement operators in v1" in {
+      Given("Job spec with both EQ and IS placement operators")
+      val specJson =
+        """{
+          |  "id": "prod.example.app",
+          |  "run": {
+          |    "cmd": "sleep 10000",
+          |    "cpus": 1,
+          |    "mem": 32,
+          |    "disk": 128,
+          |    "placement": {
+          |      "constraints": [
+          |        {
+          |          "attribute": "heaven",
+          |          "operator": "EQ",
+          |          "value": "a myth"
+          |        },
+          |        {
+          |          "attribute": "hell",
+          |          "operator": "IS",
+          |          "value": "round the corner"
+          |        }
+          |      ]
+          |    }
+          |  }
+          |}""".stripMargin
+
+      When("the job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(Json.parse(specJson))).get
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+
+      Then("the EQ has been converted to an IS operator")
+      val constraints = contentAsJson(response).as[JobSpec].run.placement.constraints
+      constraints must have size 2
+      constraints.contains(ConstraintSpec("heaven", Operator.Is, Some("a myth"))) mustBe true
+      constraints.contains(ConstraintSpec("hell", Operator.Is, Some("round the corner"))) mustBe true
+    }
+
+    "convert EQ and allow IS placement operators in v0" in {
+      Given("Job spec with both EQ and IS placement operators")
+      val specJson =
+        """{
+          |  "id": "prod.example.app",
+          |  "run": {
+          |    "cmd": "sleep 10000",
+          |    "cpus": 1,
+          |    "mem": 32,
+          |    "disk": 128,
+          |    "placement": {
+          |      "constraints": [
+          |        {
+          |          "attribute": "heaven",
+          |          "operator": "EQ",
+          |          "value": "a myth"
+          |        },
+          |        {
+          |          "attribute": "hell",
+          |          "operator": "IS",
+          |          "value": "round the corner"
+          |        }
+          |      ]
+          |    }
+          |  }
+          |}""".stripMargin
+
+      When("the job is created")
+      val response = route(app, FakeRequest(POST, s"/v0/scheduled-jobs").withJsonBody(Json.parse(specJson))).get
+      status(response) mustBe CREATED
+      contentType(response) mustBe Some("application/json")
+
+      Then("the EQ has been converted to an IS operator")
+      val constraints = contentAsJson(response).as[JobSpec].run.placement.constraints
+      constraints must have size 2
+      constraints.contains(ConstraintSpec("heaven", Operator.Is, Some("a myth"))) mustBe true
+      constraints.contains(ConstraintSpec("hell", Operator.Is, Some("round the corner"))) mustBe true
+    }
+
+    "fail for invalid placement operator" in {
+      Given("Job spec with an invalid placement operator")
+      val specJson =
+        """{
+          |  "id": "prod.example.app",
+          |  "run": {
+          |    "cmd": "sleep 10000",
+          |    "cpus": 1,
+          |    "mem": 32,
+          |    "disk": 128,
+          |    "placement": {
+          |      "constraints": [
+          |        {
+          |          "attribute": "foo",
+          |          "operator": "invalid",
+          |          "value": "bar"
+          |        }
+          |      ]
+          |    }
+          |  }
+          |}""".stripMargin
+
+      When("the job is created")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(Json.parse(specJson))).get
+
+      Then("a validation error is returned")
+      status(response) mustBe UNPROCESSABLE_ENTITY
+      contentType(response) mustBe Some("application/json")
+    }
   }
 
   "GET /jobs" should {

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,19 @@
 # Unreleased
 
-## In replaces Eq operator
+* Fix [DCOS_OSS-4978](https://jira.mesosphere.com/browse/DCOS_OSS-4978) Adjust schemas to allow IS as a valid placement constraint operator
 
-In order to bring better alignment between Marathon and Metronome, the Eq constraint operator has been replaced with In. The change is semantic; Job definitions using Eq will continue to function the same and are transparently mapped to the new operator with the same constraint behavior.
+# 0.5.71
+
+Metronome uses Marathon as a library for scheduling. We have bumped the dependency to the current Marathon, which is 1.7.183.
+This brings a lot of bug fixes and new features from the last 3 versions of Marathon. At the same time, it allows us to add UCR and secrets support.
+
+## Breaking changes
+
+Metronome 0.5.71 contains new Metrics endpoint with new metrics exposed that should allow you to monitor Metronome more easily. For detailed information please refer to the Metrics page in our docs.
+
+## IS replaces EQ operator
+
+In order to bring better alignment between Marathon and Metronome, the `EQ` constraint operator has been replaced with `IS`. The change is semantic; Job definitions using `EQ` will continue to function the same and are transparently mapped to the new operator with the same constraint behavior.
 
 If you post the following Job definition:
 
@@ -19,7 +30,7 @@ If you post the following Job definition:
 }
 ```
 
-When you ask for it back, the operator will be "IN":
+When you ask for it back, the operator will be "IS":
 
 ```json
 {
@@ -28,7 +39,7 @@ When you ask for it back, the operator will be "IN":
   "run": {
     ...
     "placement": {
-      "constraints": [{"attribute": "@region", "operator": "IN", "value": "us-east-1"}]
+      "constraints": [{"attribute": "@region", "operator": "IS", "value": "us-east-1"}]
     }
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/model/PlacementSpecTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/PlacementSpecTest.scala
@@ -2,8 +2,11 @@ package dcos.metronome.model
 
 import org.scalatest.{ FunSuite, Matchers }
 
-class PlacementSpecSpec extends FunSuite with Matchers {
+class PlacementSpecTest extends FunSuite with Matchers {
   test("Operator unapply converts EQ to IS") {
     Operator.unapply("EQ").get.shouldEqual(Operator.Is)
+  }
+  test("Operator unapply IS") {
+    Operator.unapply("IS").get.shouldEqual(Operator.Is)
   }
 }


### PR DESCRIPTION

* Adjust schemas to allow IS as a valid placement constraint operator.

Summary:
DCOS_OSS-4464 introduced the IS operator as a replacement for EQ via #287. Even though a conversion was added from EQ to IS, we missed to add IS to the enumeration for placement constraint operators. This commit adjusts the schemas for v0 and v1 accordingly.

JIRA issues: DCOS_OSS-4978

* Fixed original changelog entry and added new one for 0.6.12
