### PR TITLE
Improve secrets validation to only point out unprovided secrets

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/Authorization.scala
+++ b/api/src/main/scala/dcos/metronome/api/Authorization.scala
@@ -7,16 +7,16 @@ import java.util.concurrent.TimeUnit
 import akka.util.ByteString
 import dcos.metronome.jobinfo.JobSpecSelector
 import dcos.metronome.jobrun.StartedJobRun
-import dcos.metronome.model.{JobRun, JobSpec, QueuedJobRunInfo}
+import dcos.metronome.model.{ JobRun, JobSpec, QueuedJobRunInfo }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.metrics.current.UnitOfMeasurement
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.plugin.http.{HttpRequest, HttpResponse}
-import play.api.http.{HeaderNames, HttpEntity, Status}
+import mesosphere.marathon.plugin.http.{ HttpRequest, HttpResponse }
+import play.api.http.{ HeaderNames, HttpEntity, Status }
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 /**
   * A request that adds the User for the current call

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -294,6 +294,7 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       Then("A validation error is returned")
       status(response) mustBe UNPROCESSABLE_ENTITY
       contentType(response) mustBe Some("application/json")
+      contentAsString(response).contains("secretId") mustBe true
     }
 
     "indicate a problem when creating a job which contains fields both for secret and normal volume" in {

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -285,16 +285,15 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       contentType(response) mustBe Some("application/json")
     }
 
-    "indicate a problem when creating a job without a secret name" in {
+    "indicate no problem when creating a job with unused secrets" in {
       Given("No job")
 
       When("A job is created")
       val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSecretDefsOnlyJson)).get
 
       Then("A validation error is returned")
-      status(response) mustBe UNPROCESSABLE_ENTITY
+      status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
-      //      contentAsJson(response) \ "message" mustBe JsDefined(JsString("Object is not valid"))
     }
 
     "indicate a problem when creating a job which contains fields both for secret and normal volume" in {

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -285,14 +285,14 @@ class JobSpecControllerTest extends PlaySpec with OneAppPerTestWithComponents[Mo
       contentType(response) mustBe Some("application/json")
     }
 
-    "indicate no problem when creating a job with unused secrets" in {
+    "indicate a problem when creating a job with unused secrets" in {
       Given("No job")
 
       When("A job is created")
       val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSecretDefsOnlyJson)).get
 
       Then("A validation error is returned")
-      status(response) mustBe CREATED
+      status(response) mustBe UNPROCESSABLE_ENTITY
       contentType(response) mustBe Some("application/json")
     }
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Next
+
+* [DCOS_OSS-5019](https://jira.mesosphere.com/browse/DCOS_OSS-5019) Improve secrets validation to only point out unprovided secrets
+
 # 0.6.18
 
 * [DCOS_OSS-4636](https://jira.mesosphere.com/browse/DCOS_OSS-4636) Failure when restart policy is `ON_FAILURE`.  This bug was introduced through the fix of another bug regarding stopping invalid extra instances of a job run.  Metronome should not check the launch queue when a restart is invoked.

--- a/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
@@ -8,7 +8,7 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
     Given("a JobRunSpec with undefined, but referenced secrets")
     val jobRunSpec = JobRunSpec(
       cmd = Some("sleep 1000"),
-      volumes = Seq(SecretVolume("path", "undefined-secret")))
+      volumes = Seq(SecretVolume("path", "undefined-vol-secret")))
 
     When("The spec is validated")
     val result = JobRunSpec.validJobRunSpec(jobRunSpec)
@@ -21,7 +21,7 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
     Given("a JobRunSpec with undefined, but referenced secrets")
     val jobRunSpec = JobRunSpec(
       cmd = Some("sleep 1000"),
-      env = Map("SECRET_VAR" -> EnvVarSecret("undefined-secret")))
+      env = Map("SECRET_VAR" -> EnvVarSecret("undefined-env-secret")))
 
     When("The spec is validated")
     val result = JobRunSpec.validJobRunSpec(jobRunSpec)
@@ -30,16 +30,32 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
     result.isFailure shouldBe true
   }
 
-  test("Unused secrets is valid") {
+  test("Unused secrets is invalid") {
     Given("a JobRunSpec with defined, but unused secrets")
     val jobRunSpec = JobRunSpec(
       cmd = Some("sleep 1000"),
-      secrets = Map("secret1" -> SecretDef("unused-secret")))
+      secrets = Map("secret" -> SecretDef("unused-secret")))
 
     When("The spec is validated")
     val result = JobRunSpec.validJobRunSpec(jobRunSpec)
 
     Then("a validation error is returned")
+    result.isFailure shouldBe true
+  }
+
+  test("Used secrets are valid") {
+    Given("a JobRunSpec with defined and used secrets")
+    val jobRunSpec = JobRunSpec(
+      cmd = Some("sleep 1000"),
+      secrets = Map("secret1" -> SecretDef("secret-def-1"), "secret2" -> SecretDef("secret-def-2")),
+      volumes = Seq(SecretVolume("path", "secret1")),
+      env = Map("SECRET_VAR" -> EnvVarSecret("secret2")))
+
+    When("The spec is validated")
+    val result = JobRunSpec.validJobRunSpec(jobRunSpec)
+    println(result)
+
+    Then("validation passes")
     result.isSuccess shouldBe true
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
@@ -1,0 +1,45 @@
+package dcos.metronome
+package model
+
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
+
+class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen {
+  test("Undefined file based secret is invalid") {
+    Given("a JobRunSpec with undefined, but referenced secrets")
+    val jobRunSpec = JobRunSpec(
+      cmd = Some("sleep 1000"),
+      volumes = Seq(SecretVolume("path", "undefined-secret")))
+
+    When("The spec is validated")
+    val result = JobRunSpec.validJobRunSpec(jobRunSpec)
+
+    Then("a validation error is returned")
+    result.isFailure shouldBe true
+  }
+
+  test("Undefined env var secret is invalid") {
+    Given("a JobRunSpec with undefined, but referenced secrets")
+    val jobRunSpec = JobRunSpec(
+      cmd = Some("sleep 1000"),
+      env = Map("SECRET_VAR" -> EnvVarSecret("undefined-secret")))
+
+    When("The spec is validated")
+    val result = JobRunSpec.validJobRunSpec(jobRunSpec)
+
+    Then("a validation error is returned")
+    result.isFailure shouldBe true
+  }
+
+  test("Unused secrets is valid") {
+    Given("a JobRunSpec with defined, but unused secrets")
+    val jobRunSpec = JobRunSpec(
+      cmd = Some("sleep 1000"),
+      secrets = Map("secret1" -> SecretDef("unused-secret")))
+
+    When("The spec is validated")
+    val result = JobRunSpec.validJobRunSpec(jobRunSpec)
+
+    Then("a validation error is returned")
+    result.isSuccess shouldBe true
+  }
+}

--- a/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/JobRunSpecValidatorTest.scala
@@ -15,6 +15,7 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
 
     Then("a validation error is returned")
     result.isFailure shouldBe true
+    result.toFailure.toString.contains("undefined-vol-secret") shouldBe true
   }
 
   test("Undefined env var secret is invalid") {
@@ -28,6 +29,7 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
 
     Then("a validation error is returned")
     result.isFailure shouldBe true
+    result.toFailure.toString.contains("undefined-env-secret") shouldBe true
   }
 
   test("Unused secrets is invalid") {
@@ -41,6 +43,7 @@ class JobRunSpecValidatorTest extends FunSuite with Matchers with GivenWhenThen 
 
     Then("a validation error is returned")
     result.isFailure shouldBe true
+    result.toFailure.toString.contains("unused-secret") shouldBe true
   }
 
   test("Used secrets are valid") {


### PR DESCRIPTION
Summary:
This commit adjusts secrets validation to provide helpful error messages when secrets are defined but not referenced, or referenced but not defined.

JIRA issues: DCOS_OSS-5019