### PR TITLE
Fix marathon version reported in info endpoint

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/Authorization.scala
+++ b/api/src/main/scala/dcos/metronome/api/Authorization.scala
@@ -7,15 +7,15 @@ import java.util.concurrent.TimeUnit
 import akka.util.ByteString
 import dcos.metronome.jobinfo.JobSpecSelector
 import dcos.metronome.jobrun.StartedJobRun
-import dcos.metronome.model.{JobRun, JobSpec, QueuedJobRunInfo}
+import dcos.metronome.model.{ JobRun, JobSpec, QueuedJobRunInfo }
 import mesosphere.marathon.metrics.Metrics
 import mesosphere.marathon.plugin.auth._
-import mesosphere.marathon.plugin.http.{HttpRequest, HttpResponse}
-import play.api.http.{HeaderNames, HttpEntity, Status}
+import mesosphere.marathon.plugin.http.{ HttpRequest, HttpResponse }
+import play.api.http.{ HeaderNames, HttpEntity, Status }
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
 
 /**
   * A request that adds the User for the current call

--- a/jobs/src/main/scala/dcos/metronome/MarathonBuildInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/MarathonBuildInfo.scala
@@ -1,0 +1,64 @@
+package dcos.metronome
+
+import java.util.jar.{ Attributes, Manifest }
+
+import mesosphere.marathon.SemVer
+import mesosphere.marathon.io.IO
+import mesosphere.marathon.stream.Implicits._
+
+import scala.Predef._
+import scala.util.control.NonFatal
+
+case object MarathonBuildInfo {
+  private val marathonJar = """\/mesosphere\/marathon\/marathon_2.12\/[0-9.]+""".r
+  val DefaultBuildVersion = SemVer(1, 7, 0, Some("SNAPSHOT"))
+
+  /**
+    * sbt-native-package provides all of the files as individual JARs. By default, `getResourceAsStream` returns the
+    * first matching file for the first JAR in the class path. Instead, we need to enumerate through all of the
+    * manifests, and find the one that applies to the Marathon application jar.
+    */
+  private lazy val marathonManifestPath: List[java.net.URL] =
+    getClass().getClassLoader().getResources("META-INF/MANIFEST.MF").toIterator.filter { manifest =>
+      println(manifest.getPath)
+      marathonJar.findFirstMatchIn(manifest.getPath).nonEmpty
+    }.toList
+
+  lazy val manifest: Option[Manifest] = marathonManifestPath match {
+    case Nil => None
+    case List(file) =>
+      val mf = new Manifest()
+      IO.using(file.openStream) { f =>
+        mf.read(f)
+        Some(mf)
+      }
+    case otherwise =>
+      throw new RuntimeException(s"Multiple marathon JAR manifests returned! ${otherwise}")
+  }
+
+  lazy val attributes: Option[Attributes] = manifest.map(_.getMainAttributes())
+
+  def getAttribute(name: String): Option[String] = attributes.flatMap { attrs =>
+    try {
+      Option(attrs.getValue(name))
+    } catch {
+      case NonFatal(_) => None
+    }
+  }
+
+  lazy val name: String = getAttribute("Implementation-Title").getOrElse("unknown")
+
+  // IntelliJ has its own manifest.mf that will inject a version that doesn't necessarily match
+  // our actual version. This can cause Migrations to fail since the version number doesn't correctly match up.
+  lazy val version: SemVer = getAttribute("Implementation-Version").filterNot(_ == "0.1-SNAPSHOT").map(SemVer(_)).getOrElse(DefaultBuildVersion)
+
+  lazy val scalaVersion: String = getAttribute("Scala-Version").getOrElse("2.x.x")
+
+  lazy val buildref: String = getAttribute("Git-Commit").getOrElse("unknown")
+
+  override val toString: String = {
+    "name: %s, version: %s, scalaVersion: %s, buildref: %s" format (
+      name, version, scalaVersion, buildref)
+  }
+}
+

--- a/jobs/src/main/scala/dcos/metronome/MarathonBuildInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/MarathonBuildInfo.scala
@@ -20,7 +20,6 @@ case object MarathonBuildInfo {
     */
   private lazy val marathonManifestPath: List[java.net.URL] =
     getClass().getClassLoader().getResources("META-INF/MANIFEST.MF").toIterator.filter { manifest =>
-      println(manifest.getPath)
       marathonJar.findFirstMatchIn(manifest.getPath).nonEmpty
     }.toList
 

--- a/jobs/src/main/scala/dcos/metronome/MetronomeBuildInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/MetronomeBuildInfo.scala
@@ -2,7 +2,6 @@ package dcos.metronome
 
 import java.util.jar.{ Attributes, Manifest }
 
-import mesosphere.marathon.BuildInfo
 import mesosphere.marathon.io.IO
 
 import scala.collection.JavaConverters._
@@ -65,6 +64,6 @@ case object MetronomeBuildInfo {
 
   lazy val scalaVersion: String = getAttribute("Scala-Version").getOrElse("2.x.x")
 
-  lazy val marathonVersion: mesosphere.marathon.SemVer = BuildInfo.version
+  lazy val marathonVersion: mesosphere.marathon.SemVer = MarathonBuildInfo.version
 
 }

--- a/jobs/src/test/scala/dcos/metronome/MarathonBuildInfoTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/MarathonBuildInfoTest.scala
@@ -1,0 +1,13 @@
+package dcos.metronome
+
+import org.scalatest.{ Matchers, WordSpec }
+
+class MarathonBuildInfoTest extends WordSpec with Matchers {
+
+  "BuildInfo" should {
+    "return a default version" in {
+      // metronome should never depend on snapshot version of marathon
+      MarathonBuildInfo.version.toString().contains("SNAPSHOT") should be(false)
+    }
+  }
+}


### PR DESCRIPTION
The marathon version was incorrectly reported, it was always the default of 1.7.0-SNAPSHOT. I believe that we cannot use the same regex as we use in marathon here thus I copypasted the build info class and changed the regex.
