### PR TITLE
Remove timer.seconds as that is already added

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/Authorization.scala
+++ b/api/src/main/scala/dcos/metronome/api/Authorization.scala
@@ -86,7 +86,7 @@ abstract class Authorization(
   private[this] val http4XX = metrics.counter("http.responses.4xx.rate")
   private[this] val http5XX = metrics.counter("http.responses.5xx.rate")
   private[this] val apiErrors = metrics.counter("http.responses.errors.rate")
-  private[this] val requestDurationMetric = metrics.timer("http.requests.duration.timer.seconds")
+  private[this] val requestDurationMetric = metrics.timer("http.requests.duration")
   private[this] val requestSizeMetric = metrics.counter("http.requests.size")
   private[this] val responseSizeMetric = metrics.counter("http.responses.size")
 


### PR DESCRIPTION
There is convention that already does that if we use these interfaces/implementation we use. See https://github.com/mesosphere/marathon/blob/db1da90ae6515f55faf59b110f18851c3ad2134a/src/main/scala/mesosphere/marathon/metrics/current/DropwizardMetrics.scala#L104