### PR TITLE
Fix containerPath for secrets example

### DIFF
--- a/docs/docs/secrets.md
+++ b/docs/docs/secrets.md
@@ -64,7 +64,7 @@ In the example below, the secret will have the filename /mnt/test and will be av
     },
     "volumes": [
          {
-           "containerPath": "/mnt/test",
+           "containerPath": "mnt/test",
            "secret": "secret1"
          }
     ],


### PR DESCRIPTION
The example with leading slash doesn't work