### PR TITLE
Add taskids into history

### DIFF
--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -32,6 +32,7 @@ message JobHistory {
     optional JobRun.Id job_run_id = 1;
     optional int64 created_at = 2;
     optional int64 finishedAt = 3;
+    repeated string tasks = 4;
   }
   repeated JobRunInfo successful_runs = 6;
   repeated JobRunInfo failed_runs = 7;

--- a/jobs/src/main/scala/dcos/metronome/model/JobHistory.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobHistory.scala
@@ -3,6 +3,8 @@ package model
 
 import java.time.{ Clock, Instant }
 
+import mesosphere.marathon.core.task.Task
+
 case class JobHistorySummary(
   jobSpecId:     JobId,
   successCount:  Long,
@@ -29,9 +31,9 @@ object JobHistory {
   def empty(id: JobId): JobHistory = JobHistory(id, 0, 0, None, None, Seq.empty, Seq.empty)
 }
 
-case class JobRunInfo(id: JobRunId, createdAt: Instant, finishedAt: Instant)
+case class JobRunInfo(id: JobRunId, createdAt: Instant, finishedAt: Instant, tasks: Seq[Task.Id])
 object JobRunInfo {
   def apply(run: JobRun): JobRunInfo = {
-    JobRunInfo(run.id, run.createdAt, Clock.systemUTC().instant())
+    JobRunInfo(run.id, run.createdAt, Clock.systemUTC().instant(), run.tasks.keys.to[Seq])
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshaller.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 
 import dcos.metronome.model.{ JobHistory, JobId, JobRunInfo }
 import dcos.metronome.repository.impl.kv.EntityMarshaller
+import mesosphere.marathon.core.task.Task
 import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
@@ -72,7 +73,8 @@ object JobHistoryConversions {
       JobRunInfo(
         id = proto.getJobRunId.toModel,
         createdAt = Instant.ofEpochMilli(proto.getCreatedAt),
-        finishedAt = Instant.ofEpochMilli(proto.getFinishedAt))
+        finishedAt = Instant.ofEpochMilli(proto.getFinishedAt),
+        tasks = proto.getTasksList.asScala.map(Task.Id(_)).to[Seq])
     }.toList
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshaller.scala
@@ -58,11 +58,14 @@ object JobHistoryConversions {
     import JobRunConversions.JobRunIdToProto
 
     def toProto: Seq[Protos.JobHistory.JobRunInfo] = jobRunInfos.map { jobRunInfo =>
-      Protos.JobHistory.JobRunInfo.newBuilder()
+      val proto = Protos.JobHistory.JobRunInfo.newBuilder()
         .setJobRunId(jobRunInfo.id.toProto)
         .setCreatedAt(jobRunInfo.createdAt.toEpochMilli)
         .setFinishedAt(jobRunInfo.finishedAt.toEpochMilli)
-        .build()
+
+      proto.addAllTasks(jobRunInfo.tasks.map(_.idString).asJava)
+
+      proto.build()
     }
   }
 

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobHistoryMarshallerTest.scala
@@ -4,6 +4,7 @@ package repository.impl.kv.marshaller
 import java.time.{ Clock, LocalDateTime, ZoneOffset }
 
 import dcos.metronome.model._
+import mesosphere.marathon.core.task.Task
 import org.scalatest.{ FunSuite, Matchers }
 
 class JobHistoryMarshallerTest extends FunSuite with Matchers {
@@ -21,12 +22,14 @@ class JobHistoryMarshallerTest extends FunSuite with Matchers {
     val successfulJobRunInfo = JobRunInfo(
       JobRunId(JobId("/test"), "successful"),
       LocalDateTime.parse("2004-09-06T08:50:12.000").toInstant(ZoneOffset.UTC),
-      LocalDateTime.parse("2014-09-06T08:50:12.000").toInstant(ZoneOffset.UTC))
+      LocalDateTime.parse("2014-09-06T08:50:12.000").toInstant(ZoneOffset.UTC),
+      tasks = Seq(Task.Id("test_finished.77a7bc7d-4429-11e9-969f-3a74960279c0")))
 
     val finishedJobRunInfo = JobRunInfo(
       JobRunId(JobId("/test"), "finished"),
       LocalDateTime.parse("1984-09-06T08:50:12.000").toInstant(ZoneOffset.UTC),
-      LocalDateTime.parse("1994-09-06T08:50:12.000").toInstant(ZoneOffset.UTC))
+      LocalDateTime.parse("1994-09-06T08:50:12.000").toInstant(ZoneOffset.UTC),
+      tasks = Seq(Task.Id("test_finished.77a7bc7d-4429-11e9-969f-3a74960279c0")))
 
     val jobHistory = JobHistory(
       JobId("/my/wonderful/job"),


### PR DESCRIPTION
Summary:
Adds taskids to the history of job runs. This is needed to be able to query logs by task id when tasks are finished.

This is from a test cluster I started this morning.

```
{
   "id":"test",
   "labels":{

   },
   "run":{
      "cpus":1,
      "mem":128,
      "disk":0,
      "gpus":0,
      "cmd":"sleep 1",
      "env":{

      },
      "placement":{
         "constraints":[

         ]
      },
      "artifacts":[

      ],
      "maxLaunchDelay":3600,
      "ucr":{
         "image":{
            "id":"alpine",
            "kind":"docker",
            "forcePull":false
         },
         "privileged":false
      },
      "volumes":[

      ],
      "restart":{
         "policy":"NEVER"
      },
      "secrets":{

      }
   },
   "activeRuns":[

   ],
   "history":{
      "successCount":1,
      "failureCount":2,
      "lastSuccessAt":"2019-06-11T08:28:17.722+0000",
      "lastFailureAt":"2019-06-11T08:26:15.428+0000",
      "successfulFinishedRuns":[
         {
            "id":"20190611082632T0w4y",
            "createdAt":"2019-06-11T08:26:32.342+0000",
            "finishedAt":"2019-06-11T08:28:17.722+0000",
            "tasks":[
               "test_20190611082632T0w4y.dc3c80e6-8c22-11e9-89ca-f6185111971b"
            ]
         }
      ],
      "failedFinishedRuns":[
         {
            "id":"20190611082145nG1ta",
            "createdAt":"2019-06-11T08:21:45.262+0000",
            "finishedAt":"2019-06-11T08:26:15.428+0000",
            "tasks":[
               "test_20190611082145nG1ta.2ea877e5-8c22-11e9-89ca-f6185111971b"
            ]
         },
         {
            "id":"201906110815512U9uW",
            "createdAt":"2019-06-11T08:15:51.321+0000",
            "finishedAt":"2019-06-11T08:21:24.814+0000",
            "tasks":[
               "test_201906110815512U9uW.4b709754-8c21-11e9-89ca-f6185111971b"
            ]
         }
      ]
   }
}
```

JIRA issues: DCOS-54879
