### PR TITLE
Update status even when active

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Next
 
+# 0.6.NEXT
+
+* When querying run detail with `embed=history`, `successfulFinishedRuns` and `failedFinishedRuns` contains new field `tasks` which is an array of taskIds of that finished run. This allow people to query task ids even for finished job runs.
+
 # 0.6.21
 
 * [DCOS_OSS-5020](https://jira.mesosphere.com/browse/DCOS_OSS-5020) Add missing HTTP metrics in Metronome.

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 # 0.6.NEXT
 
 * When querying run detail with `embed=history`, `successfulFinishedRuns` and `failedFinishedRuns` contains new field `tasks` which is an array of taskIds of that finished run. This allow people to query task ids even for finished job runs.
+* Fixed a bug when task status was not updated after the task turned running (when querying embed=activeRuns).
 
 # 0.6.21
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 # 0.6.NEXT
 
-* When querying run detail with `embed=history`, `successfulFinishedRuns` and `failedFinishedRuns` contains new field `tasks` which is an array of taskIds of that finished run. This allow people to query task ids even for finished job runs.
+* When querying run detail with `embed=history`, `successfulFinishedRuns` and `failedFinishedRuns` contains new field `tasks` which is an array of taskIds of that finished run. This will allow people to query task ids even for finished job runs.
 * Fixed a bug when task status was not updated after the task turned running (when querying embed=activeRuns).
 
 # 0.6.21

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunExecutorActor.scala
@@ -301,6 +301,10 @@ class JobRunExecutorActor(
 
   def active: Receive = {
     receiveKill orElse {
+      case ForwardStatusUpdate(update) if isActive(update.taskState) =>
+        jobRun = jobRun.copy(status = JobRunStatus.Active, tasks = updatedTasks(update))
+        persistenceActor ! Update(_ => jobRun)
+        context.parent ! JobRunUpdate(StartedJobRun(jobRun, promise.future))
       case ForwardStatusUpdate(update) if isFinished(update.taskState) =>
         becomeFinishing(jobRun.copy(
           status = JobRunStatus.Success,

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceActor.scala
@@ -147,10 +147,10 @@ class JobRunServiceActor(
 
     allRunExecutors.get(jobRunId) match {
       case Some(actorRef) =>
-        log.debug("Forwarding status update to {}", actorRef.path)
+        log.info("Forwarding status update {} to {}", update, actorRef.path)
         actorRef ! ForwardStatusUpdate(update)
       case None =>
-        log.debug("Ignoring TaskStateChangedEvent for {}. No one interested.", jobRunId)
+        log.info("Ignoring TaskStateChangedEvent for {}. No one interested.", jobRunId)
     }
   }
 

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -65,8 +65,8 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     When("A subsequent RUNNING update is processed")
     actor ! f.statusUpdate(TaskState.Running)
 
-    Then("Nothing is persisted because the JobRunStatus is still Active")
-    f.persistenceActor.expectNoMsg(500.millis)
+    Then("New task status is persisted")
+    f.persistenceActor.expectMsgType[JobRunPersistenceActor.Update]
 
     And("No additional message is send because the job is still active")
     f.parent.expectNoMsg(500.millis)

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -67,9 +67,6 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
 
     Then("New task status is persisted")
     f.persistenceActor.expectMsgType[JobRunPersistenceActor.Update]
-
-    And("No additional message is send because the job is still active")
-    f.parent.expectNoMsg(500.millis)
   }
 
   test("ForwardStatusUpdate FINISHED") {


### PR DESCRIPTION
Summary:
Right now, for a running job, task status never goes from Starting to Running because once we enter an active state, we stop processing these updates. We only process finished and failed. After this patch, we should propagate the right task status up to the API and UI.

JIRA issues:
