### PR TITLE
Update to Release Build Node for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ ansiColor('gnome-terminal') {
         user_is_authorized(master_branches, '8b793652-f26a-422f-a9ba-0d1e47eb9d89', '#marathon-dev')
       }
     }
-    node('JenkinsMarathonCI-Debian9-2018-04-09') {
+    node('JenkinsMarathonCI-Debian9-2019-06-19') {
       stage('Run Pipeline') {
         try {
             checkout scm

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 ansiColor('xterm') {
-  node('JenkinsMarathonCI-Debian8-2017-10-23') {
+  node('JenkinsMarathonCI-Debian9-2019-06-19') {
 
     properties([
       parameters([

--- a/ci/si_install_deps.sh
+++ b/ci/si_install_deps.sh
@@ -17,7 +17,7 @@ fi
 
 # Ensure amm is available.
 if ! command -v amm >/dev/null 2>&1; then
-    curl -L -o /usr/local/bin/amm https://github.com/lihaoyi/Ammonite/releases/download/1.1.0/2.12-1.1.0 && \
+    curl -L -o /usr/local/bin/amm https://github.com/lihaoyi/Ammonite/releases/download/1.5.0/2.12-1.5.0 && \
     chmod +x /usr/local/bin/amm && \
     echo "Ammonite successfully installed"
 fi


### PR DESCRIPTION

Summary:
updating to a later version of build node to try to avoid the apt-get lock issue

JIRA issues:
