### PR TITLE
Introducing customizable JobRuns

### DIFF
--- a/api/src/main/resources/public/api/v1/examples/run_override.json
+++ b/api/src/main/resources/public/api/v1/examples/run_override.json
@@ -1,0 +1,14 @@
+{
+  "placement": {
+    "constraints": [
+      {
+        "attribute": "rack",
+        "operator": "IS",
+        "value": "rack-1"
+      }
+    ]
+  },
+  "env": {
+    "DATA_URL": "path/to/my/data"
+  }
+}

--- a/api/src/main/resources/public/api/v1/schema/jobrunoverride.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobrunoverride.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "env": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "description": "An environment variable set to a secret",
+              "properties": {
+                "secret": {
+                  "type": "string",
+                  "documentation": "The name of the secret to refer to. At runtime, the value of the secret will be injected into the value of the variable."
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "placement": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "constraints": {
+          "type": "array",
+          "description": "The array of constraints to place this job.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "attribute": {
+                "type": "string",
+                "description": "The attribute name for this constraint."
+              },
+              "operator": {
+                "type": "string",
+                "description": "The operator for this constraint.",
+                "enum": ["IS", "EQ", "LIKE", "UNLIKE"]
+              },
+              "value": {
+                "type": "string",
+                "description": "The value for this constraint."
+              }
+            },
+            "required": ["attribute", "operator"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
@@ -34,7 +34,7 @@ class ScheduledJobSpecController(
     }
   }
 
-  def updateJob(id: JobId) = AuthorizedAction.async(validate.jsonWith[JobSpec](_.copy(id = id))) { implicit request =>
+  def updateJob(id: JobId) = AuthorizedAction.async(validate.jsonWith[JobSpec](optionalBody = false)(_.copy(id = id))) { implicit request =>
     request.authorizedAsync(UpdateRunSpec) { jobSpec =>
       jobSpecService.updateJobSpec(id, _ => jobSpec).map(Ok(_)).recover {
         case JobSpecDoesNotExist(_) => NotFound(UnknownJob(id))

--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
@@ -69,7 +69,6 @@ class JobRunController(
   def triggerJob(id: JobId) = measured {
     AuthorizedAction.async(validate.optionalJson[JobRunSpecOverrides]) { implicit request =>
       val overrides = request.body
-      JobRunController.log.info(s"overrides: $overrides")
 
       async {
         await(jobSpecService.getJobSpec(id)) match {

--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobScheduleController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobScheduleController.scala
@@ -60,7 +60,7 @@ class JobScheduleController(
   }
 
   def updateSchedule(id: JobId, scheduleId: String) = measured {
-    AuthorizedAction.async(validate.jsonWith[ScheduleSpec](_.copy(id = scheduleId))) { implicit request =>
+    AuthorizedAction.async(validate.jsonWith[ScheduleSpec](optionalBody = false)(_.copy(id = scheduleId))) { implicit request =>
       def changeSchedule(jobSpec: JobSpec) = {
         require(jobSpec.schedules.count(_.id == scheduleId) == 1, "Can only update an existing schedule")
         jobSpec.copy(schedules = request.body +: jobSpec.schedules.filterNot(_.id == scheduleId))

--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
@@ -54,7 +54,7 @@ class JobSpecController(
   }
 
   def updateJob(id: JobId) = measured {
-    AuthorizedAction.async(validate.jsonWith[JobSpec](_.copy(id = id))) { implicit request =>
+    AuthorizedAction.async(validate.jsonWith[JobSpec](optionalBody = false)(_.copy(id = id))) { implicit request =>
       request.authorizedAsync(UpdateRunSpec) { jobSpec =>
         def updateJob(job: JobSpec): JobSpec = jobSpec.copy(schedules = job.schedules)
         jobSpecService.updateJobSpec(id, updateJob).map(Ok(_)).recover {

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -209,6 +209,10 @@ package object models {
     (__ \ "taskKillGracePeriodSeconds").formatNullable[FiniteDuration] ~
     (__ \ "secrets").formatNullable[Map[String, SecretDef]].withDefault(JobRunSpec.DefaultSecrets))(JobRunSpec.apply, unlift(JobRunSpec.unapply))
 
+  implicit lazy val JobRunOverrideSpecFormat: Format[JobRunSpecOverrides] = (
+    (__ \ "env").formatNullable[Map[String, EnvVarValueOrSecret]].withDefault(JobRunSpec.DefaultEnv) ~
+    (__ \ "placement").formatNullable[PlacementSpec].withDefault(JobRunSpec.DefaultPlacement)) (JobRunSpecOverrides.apply, unlift(JobRunSpecOverrides.unapply))
+
   implicit lazy val JobSpecFormat: Format[JobSpec] = (
     (__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
@@ -245,6 +249,7 @@ package object models {
     override def writes(run: JobRun): JsValue = Json.obj(
       "id" -> run.id,
       "jobId" -> run.jobSpec.id,
+      "overrides" -> run.overrides,
       "status" -> run.status,
       "createdAt" -> run.createdAt,
       "completedAt" -> run.completedAt,

--- a/api/src/main/scala/dcos/metronome/api/v1/models/schema/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/schema/package.scala
@@ -2,7 +2,7 @@ package dcos.metronome
 package api.v1.models
 
 import dcos.metronome.api.JsonSchema
-import dcos.metronome.model.{ ScheduleSpec, JobSpec }
+import dcos.metronome.model.{ JobRunSpecOverrides, JobSpec, ScheduleSpec }
 
 package object schema {
 
@@ -11,5 +11,8 @@ package object schema {
   }
   implicit lazy val ScheduledSpecSchema: JsonSchema[ScheduleSpec] = {
     JsonSchema.fromResource("/public/api/v1/schema/schedulespec.schema.json")
+  }
+  implicit lazy val JobRunSpecOverrideSchema: JsonSchema[JobRunSpecOverrides] = {
+    JsonSchema.fromResource("/public/api/v1/schema/jobrunoverride.schema.json")
   }
 }

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -78,6 +78,42 @@ message JobRun {
   }
   repeated JobRunTask tasks = 6;
   optional int64 starting_deadline_seconds = 7;
+
+  message JobRunSpecOverrides {
+    repeated EnvironmentVariable environment = 1;
+    optional PlacementSpec placement = 2;
+  }
+  optional JobRunSpecOverrides overrides = 8;
+}
+
+/**
+ * Key, value pair used to store environment variables.
+ */
+message EnvironmentVariable {
+  optional string key = 1;
+  optional string value = 2;
+}
+message PlacementSpec {
+  message Constraint {
+    optional string attribute = 1;
+
+    enum Operator {
+      UNKNOWN = 1;
+      // Tasks will be clustered, i.e. all tasks need to have the same value. If value is not set, any value will be
+      // accepted for the first task, and subsequent tasks must use that same value.
+      EQ = 2;
+      // Field must match the regex given by value.
+      LIKE = 3;
+      // Field must not match the regex given by value.
+      UNLIKE = 4;
+      // Field must be the specified value
+      IS = 6;
+    }
+    optional Operator operator = 2;
+    optional string value = 3;
+  }
+
+  repeated Constraint constraints = 1;
 }
 
 message JobSpec {
@@ -111,37 +147,8 @@ message JobSpec {
     optional string user = 6;
     optional int32 gpus = 18;
 
-    /**
-     * Key, value pair used to store environment variables.
-     */
-    message EnvironmentVariable {
-      optional string key = 1;
-      optional string value = 2;
-    }
     repeated EnvironmentVariable environment = 7;
 
-    message PlacementSpec {
-      message Constraint {
-        optional string attribute = 1;
-
-        enum Operator {
-          UNKNOWN = 1;
-          // Tasks will be clustered, i.e. all tasks need to have the same value. If value is not set, any value will be
-          // accepted for the first task, and subsequent tasks must use that same value.
-          EQ = 2;
-          // Field must match the regex given by value.
-          LIKE = 3;
-          // Field must not match the regex given by value.
-          UNLIKE = 4;
-          // Field must be the specified value
-          IS = 6;
-        }
-        optional Operator operator = 2;
-        optional string value = 3;
-      }
-
-      repeated Constraint constraints = 1;
-    }
     optional PlacementSpec placement = 8;
 
     message Artifact {

--- a/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/JobRunService.scala
@@ -39,9 +39,10 @@ trait JobRunService {
     * In order to register an on complete hook, you can use the complete future in StartedJobRun.
     *
     * @param jobSpec the specification to run.
+    * @param overrides additional parameters that are used to override the job spec config
     * @return the started job run
     */
-  def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun]
+  def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, overrides: JobRunSpecOverrides = JobRunSpecOverrides.empty): Future[StartedJobRun]
 
   /**
     * Kill a given job run by the given job run id.

--- a/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobrun/impl/JobRunServiceDelegate.scala
@@ -40,7 +40,11 @@ private[jobrun] class JobRunServiceDelegate(
     actorRef.ask(GetActiveJobRuns(jobId)).mapTo[Iterable[StartedJobRun]]
   }
 
-  override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun] = startRunTimeMetric {
-    actorRef.ask(TriggerJobRun(jobSpec, schedule)).mapTo[StartedJobRun]
-  }
+  override def startJobRun(
+    jobSpec:   JobSpec,
+    schedule:  Option[ScheduleSpec] = None,
+    overrides: JobRunSpecOverrides  = JobRunSpecOverrides.empty): Future[StartedJobRun] =
+    startRunTimeMetric {
+      actorRef.ask(TriggerJobRun(jobSpec, schedule, overrides)).mapTo[StartedJobRun]
+    }
 }

--- a/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRun.scala
@@ -11,6 +11,7 @@ import scala.concurrent.duration.Duration
 case class JobRun(
   id:               JobRunId,
   jobSpec:          JobSpec,
+  overrides:        JobRunSpecOverrides,
   status:           JobRunStatus,
   createdAt:        Instant,
   completedAt:      Option[Instant],

--- a/jobs/src/main/scala/dcos/metronome/model/JobRunSpecOverrides.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobRunSpecOverrides.scala
@@ -1,0 +1,29 @@
+package dcos.metronome.model
+
+import com.wix.accord.Validator
+
+// TODO: in order to help users to process specific data, it might be helpful to support overriding artifacts
+// TODO: decide whether we want to promote the variable names that can or need to be provided
+case class JobRunSpecOverrides(
+  env:       Map[String, EnvVarValueOrSecret] = JobRunSpec.DefaultEnv,
+  placement: PlacementSpec                    = JobRunSpec.DefaultPlacement)
+
+object JobRunSpecOverrides {
+
+  val empty: JobRunSpecOverrides = new JobRunSpecOverrides() {
+    override def toString: String = "JobRunSpecOverrides.empty"
+  }
+
+  def apply(
+    env:       Map[String, EnvVarValueOrSecret] = JobRunSpec.DefaultEnv,
+    placement: PlacementSpec                    = JobRunSpec.DefaultPlacement): JobRunSpecOverrides = {
+    if (env == JobRunSpec.DefaultEnv && placement == JobRunSpec.DefaultPlacement) empty
+    else new JobRunSpecOverrides(env, placement)
+  }
+
+  implicit lazy val validJobRunOverrideSpec: Validator[JobRunSpecOverrides] = new Validator[JobRunSpecOverrides] {
+    import com.wix.accord._
+
+    override def apply(spec: JobRunSpecOverrides): Result = Success
+  }
+}

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/EnvironmentMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/EnvironmentMarshaller.scala
@@ -1,0 +1,53 @@
+package dcos.metronome.repository.impl.kv.marshaller
+
+import dcos.metronome.Protos
+import dcos.metronome.model.{ EnvVarSecret, EnvVarValue, EnvVarValueOrSecret, SecretDef }
+
+import scala.collection.mutable
+
+object EnvironmentMarshaller {
+  implicit class EnvironmentToProto(val environment: Map[String, EnvVarValueOrSecret]) extends AnyVal {
+    def toEnvProto: Iterable[Protos.EnvironmentVariable] = environment.collect {
+      case (key, EnvVarValue(value)) =>
+        Protos.EnvironmentVariable.newBuilder()
+          .setKey(key)
+          .setValue(value)
+          .build
+    }
+    def toEnvSecretProto: Iterable[Protos.JobSpec.RunSpec.EnvironmentVariableSecret] = environment.collect {
+      case (name, EnvVarSecret(secretId)) =>
+        Protos.JobSpec.RunSpec.EnvironmentVariableSecret.newBuilder()
+          .setName(name)
+          .setSecretId(secretId)
+          .build
+    }
+  }
+
+  implicit class SecretsToProto(val secrets: Map[String, SecretDef]) extends AnyVal {
+    def toProto: Iterable[Protos.JobSpec.RunSpec.Secret] = secrets.map {
+      case (secretId, SecretDef(source)) =>
+        Protos.JobSpec.RunSpec.Secret.newBuilder()
+          .setId(secretId)
+          .setSource(source)
+          .build()
+    }
+  }
+
+  implicit class ProtosToEnvironment(val environmentVariables: mutable.Buffer[Protos.EnvironmentVariable]) extends AnyVal {
+    def toModel: Map[String, EnvVarValueOrSecret] = environmentVariables.map { environmentVariable =>
+      environmentVariable.getKey -> EnvVarValue(environmentVariable.getValue)
+    }.toMap
+  }
+
+  implicit class ProtosToEnvironmentSecrets(val environmentSecrets: mutable.Buffer[Protos.JobSpec.RunSpec.EnvironmentVariableSecret]) extends AnyVal {
+    def toModel: Map[String, EnvVarValueOrSecret] = environmentSecrets.map { environmentSecret =>
+      environmentSecret.getName -> EnvVarSecret(environmentSecret.getSecretId)
+    }.toMap
+  }
+
+  implicit class ProtosToSecrets(val secrets: mutable.Buffer[Protos.JobSpec.RunSpec.Secret]) extends AnyVal {
+    def toModel: Map[String, SecretDef] = secrets.map { secret =>
+      secret.getId -> SecretDef(secret.getSource)
+    }.toMap
+  }
+}

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/PlacementMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/PlacementMarshaller.scala
@@ -1,0 +1,45 @@
+package dcos.metronome.repository.impl.kv.marshaller
+
+import dcos.metronome.Protos
+import dcos.metronome.model.{ ConstraintSpec, Operator, PlacementSpec }
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.Seq
+
+object PlacementMarshaller {
+  implicit class PlacementSpecToProto(val placement: PlacementSpec) extends AnyVal {
+    def toProto: Protos.PlacementSpec = {
+      Protos.PlacementSpec.newBuilder()
+        .addAllConstraints(placement.constraints.toProto.asJava)
+        .build()
+    }
+  }
+
+  implicit class ProtoToPlacementSpec(val placementSpec: Protos.PlacementSpec) extends AnyVal {
+    def toModel: PlacementSpec = PlacementSpec(constraints = placementSpec.getConstraintsList.asScala.toModel)
+  }
+
+  implicit class ConstraintsToProto(val constraints: Seq[ConstraintSpec]) extends AnyVal {
+    def toProto: Iterable[Protos.PlacementSpec.Constraint] = constraints.map { constraint =>
+      val builder = Protos.PlacementSpec.Constraint.newBuilder
+
+      constraint.value.foreach(builder.setValue)
+
+      builder
+        .setAttribute(constraint.attribute)
+        .setOperator(
+          Protos.PlacementSpec.Constraint.Operator.valueOf(constraint.operator.name))
+        .build()
+    }
+  }
+
+  implicit class ProtosToConstraintSpec(val constraints: Iterable[Protos.PlacementSpec.Constraint]) extends AnyVal {
+    def toModel: Seq[ConstraintSpec] = constraints.map { constraint =>
+      val value = if (constraint.hasValue) Some(constraint.getValue) else None
+      ConstraintSpec(
+        attribute = constraint.getAttribute,
+        operator = Operator.names(constraint.getOperator.toString),
+        value = value)
+    }(collection.breakOut)
+  }
+}

--- a/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/JobRunServiceFixture.scala
@@ -32,9 +32,9 @@ object JobRunServiceFixture {
     override def listRuns(filter: JobRun => Boolean): Future[Iterable[StartedJobRun]] = {
       Future.successful(specs.values.filter(r => filter(r.jobRun)))
     }
-    override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None): Future[StartedJobRun] = {
+    override def startJobRun(jobSpec: JobSpec, schedule: Option[ScheduleSpec] = None, overrides: JobRunSpecOverrides = JobRunSpecOverrides.empty): Future[StartedJobRun] = {
       val startingDeadline: Option[Duration] = schedule.map(_.startingDeadline)
-      val run = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, Clock.systemUTC().instant(), None, startingDeadline, Map.empty[Task.Id, JobRunTask])
+      val run = JobRun(JobRunId(jobSpec), jobSpec, overrides, JobRunStatus.Active, Clock.systemUTC().instant(), None, startingDeadline, Map.empty[Task.Id, JobRunTask])
       val startedRun = StartedJobRun(run, Promise[JobResult].future)
       specs += run.id -> startedRun
       Future.successful(startedRun)

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunExecutorActorTest.scala
@@ -320,7 +320,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
   test("Init of JobRun with JobRunStatus.Success") {
     val f = new Fixture
     import f._
-    val successfulJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Success, clock.instant(), None, None, Map.empty)
+    val successfulJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Success, clock.instant(), None, None, Map.empty)
     val actorRef: ActorRef = executorActor(successfulJobRun)
 
     verify(launchQueue, timeout(1000)).purge(successfulJobRun.id.toRunSpecId)
@@ -336,7 +336,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     val f = new Fixture
 
     Given("a jobRun in status Failed")
-    val failedJobRun = JobRun(JobRunId(f.defaultJobSpec), f.defaultJobSpec, JobRunStatus.Failed, f.clock.instant(), Some(f.clock.instant()), None, Map.empty)
+    val failedJobRun = JobRun(JobRunId(f.defaultJobSpec), f.defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Failed, f.clock.instant(), Some(f.clock.instant()), None, Map.empty)
 
     When("an executor is initialized with the failed jobRun")
     f.executorActor(failedJobRun)
@@ -349,7 +349,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     import f._
 
     Given("a JobRun with status Active")
-    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Active, clock.instant(), None, None, Map.empty)
+    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Active, clock.instant(), None, None, Map.empty)
     val runSpecId = activeJobRun.id.toRunSpecId
     f.launchQueue.get(runSpecId) returns Future.successful(None)
     instanceTracker.specInstancesSync(runSpecId) returns Seq.empty
@@ -366,7 +366,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     import f._
 
     Given("a JobRun with status Starting")
-    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Starting, clock.instant(), None, None, Map.empty)
+    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Starting, clock.instant(), None, None, Map.empty)
     val runSpecId = activeJobRun.id.toRunSpecId
     val runSpec: RunSpec = activeJobRun.toRunSpec
     val queuedTaskInfo = QueuedInstanceInfo(
@@ -394,7 +394,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     import f._
 
     Given("a JobRun with status Active")
-    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Active, clock.instant(), None, None, Map.empty)
+    val activeJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Active, clock.instant(), None, None, Map.empty)
     val runSpecId = activeJobRun.id.toRunSpecId
     val runSpec: RunSpec = activeJobRun.toRunSpec
     val queuedTaskInfo = QueuedInstanceInfo(
@@ -887,7 +887,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
       */
     def setupInitialExecutorActor(spec: Option[JobSpec] = None, startingDeadline: Option[Duration] = None, createdAt: Instant = clock.instant()): (TestActorRef[JobRunExecutorActor], JobRun) = {
       val jobSpec = spec.getOrElse(defaultJobSpec)
-      val startingJobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Initial, createdAt, None, startingDeadline, Map.empty)
+      val startingJobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunSpecOverrides.empty, JobRunStatus.Initial, createdAt, None, startingDeadline, Map.empty)
       val actorRef = executorActor(startingJobRun, startingDeadline)
       (actorRef, startingJobRun)
     }
@@ -898,7 +898,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
       * @return A tuple containing the ActorRef and the JobRun
       */
     def setupStartingExecutorActor(): (ActorRef, JobRun) = {
-      val startingJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Initial, clock.instant(), None, None, Map.empty)
+      val startingJobRun = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Initial, clock.instant(), None, None, Map.empty)
       val actorRef: ActorRef = executorActor(startingJobRun)
       val msg = persistenceActor.expectMsgType[JobRunPersistenceActor.Create]
       msg.jobRun.status shouldBe JobRunStatus.Starting
@@ -908,7 +908,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
     }
 
     def setupRunningExecutorActor(): (ActorRef, JobRun) = {
-      val activeJob = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunStatus.Active, clock.instant(), None, None,
+      val activeJob = JobRun(JobRunId(defaultJobSpec), defaultJobSpec, JobRunSpecOverrides.empty, JobRunStatus.Active, clock.instant(), None, None,
         Map(Task.Id("app_682ebe64-0771-11e4-b05d-e0f84720c54e") -> JobRunTask(Task.Id("app_682ebe64-0771-11e4-b05d-e0f84720c54e"), null, None, TaskState.Running)))
       val actorRef: ActorRef = executorActor(activeJob)
       val runSpecId = activeJob.id.toRunSpecId
@@ -930,7 +930,7 @@ class JobRunExecutorActorTest extends TestKit(ActorSystem("test"))
       */
     def setupActiveExecutorActor(spec: Option[JobSpec] = None, startingDeadline: Option[Duration] = None): (TestActorRef[JobRunExecutorActor], JobRun) = {
       val jobSpec = spec.getOrElse(defaultJobSpec)
-      val startingJobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Initial, clock.instant(), None, None, Map.empty)
+      val startingJobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunSpecOverrides.empty, JobRunStatus.Initial, clock.instant(), None, None, Map.empty)
       val actorRef: TestActorRef[JobRunExecutorActor] = executorActor(startingJobRun, startingDeadline)
       persistenceActor.expectMsgType[JobRunPersistenceActor.Create]
       persistenceActor.reply(JobRunPersistenceActor.JobRunCreated(persistenceActor.ref, startingJobRun, Unit))

--- a/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobrun/impl/JobRunServiceActorTest.scala
@@ -90,7 +90,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val actor = f.serviceActor
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
 
     Then("The list of started job runs is returned")
     val started = expectMsgClass(classOf[StartedJobRun])
@@ -105,7 +105,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val actor = f.serviceActor
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule))
+    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule), JobRunSpecOverrides.empty)
 
     Then("The list of started job runs is returned")
     val started = expectMsgClass(classOf[StartedJobRun])
@@ -119,11 +119,11 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val f = new Fixture
     val actor = f.serviceActor
     // triggered job
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("An existing jobRun is queried")
-    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule))
+    actor ! TriggerJobRun(f.jobSpec, Some(f.forbidSchedule), JobRunSpecOverrides.empty)
 
     Then("No Job Started and No Returned StartedJobRun")
     expectNoMsg()
@@ -134,7 +134,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -150,7 +150,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job aborted")
@@ -166,7 +166,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("An empty service")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("The job finished")
@@ -182,7 +182,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     Given("A service with 2 jobRuns")
     val f = new Fixture
     val actor = f.serviceActor
-    actor ! TriggerJobRun(f.jobSpec, None)
+    actor ! TriggerJobRun(f.jobSpec, None, JobRunSpecOverrides.empty)
     val startedRun = expectMsgClass(classOf[StartedJobRun])
 
     When("An existing jobRun is queried")
@@ -214,7 +214,7 @@ class JobRunServiceActorTest extends TestKit(ActorSystem("test")) with FunSuiteL
     val clock = new SettableClock(Clock.fixed(LocalDateTime.parse("2016-06-01T08:50:12.000").toInstant(ZoneOffset.UTC), ZoneOffset.UTC))
 
     def run() = {
-      val jobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunStatus.Active, clock.instant(), None, None, Map.empty[Task.Id, JobRunTask])
+      val jobRun = JobRun(JobRunId(jobSpec), jobSpec, JobRunSpecOverrides.empty, JobRunStatus.Active, clock.instant(), None, None, Map.empty[Task.Id, JobRunTask])
       StartedJobRun(jobRun, Future.successful(JobResult(jobRun)))
     }
     val run1 = run()

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/ScheduleSpecTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/ScheduleSpecTest.scala
@@ -1,10 +1,10 @@
 package dcos.metronome.jobspec.impl
 
-import java.time.{Instant, ZoneId}
+import java.time.{ Instant, ZoneId }
 
-import dcos.metronome.model.{ConcurrencyPolicy, CronSpec, ScheduleSpec}
+import dcos.metronome.model.{ ConcurrencyPolicy, CronSpec, ScheduleSpec }
 import dcos.metronome.utils.test.Mockito
-import org.scalatest.{FunSuite, GivenWhenThen, Matchers}
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.concurrent.duration._
 

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobRunMarshallerTest.scala
@@ -26,6 +26,7 @@ class JobRunMarshallerTest extends FunSuite with Matchers {
     val jobRun = JobRun(
       JobRunId(jobSpec.id, "run.id"),
       jobSpec,
+      JobRunSpecOverrides.empty,
       JobRunStatus.Active,
       LocalDateTime.parse("2004-09-06T08:50:12.000").toInstant(ZoneOffset.UTC),
       Some(LocalDateTime.parse("2004-09-06T08:50:12.000").toInstant(ZoneOffset.UTC)),

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -117,8 +117,8 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with PropertyChecks {
 
   test("reading EQ constraint comes through as IS") {
     // This asserts that jobSpecs stored with the EQ Operator are properly mapped to IS
-    import Protos.JobSpec.RunSpec.PlacementSpec.Constraint
-    import RunSpecConversions.ProtosToConstraintSpec
+    import Protos.PlacementSpec.Constraint
+    import PlacementMarshaller.ProtosToConstraintSpec
     val converted = Seq(Constraint.newBuilder().setAttribute("field").setOperator(Constraint.Operator.EQ).setValue("value").build).toModel
     converted.head.operator.name shouldBe "IS"
   }


### PR DESCRIPTION
Summary:
Metronome now allows to override environment variables and add placement constraints for manually triggered JobRuns. This added functionality allows you to treat a JobSpec as a template, and trigger customized invocations based on this template. For example, you can now use a single generic JobSpec that processes data, and invoke a JobRun pointing to a specific bucket. Or, you could invoke a JobRun on a specific agent. Either way, you don't need to create individual JobSpecs and delete them once they're no longer needed.

JIRA issues: n/a