### PR TITLE
fix auth for job runs to be constant time

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobRunController.scala
@@ -30,7 +30,6 @@ class JobRunController(
 
   def getJobRuns(id: JobId) = measured {
     AuthorizedAction.async { implicit request =>
-      //      jobRunService.activeRuns(id).map(_.filter(request.isAllowed)).map(Ok(_))
       async {
         await(jobSpecService.getJobSpec(id)) match {
           case Some(spec) =>

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/ScheduleSpecTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/ScheduleSpecTest.scala
@@ -1,10 +1,10 @@
 package dcos.metronome.jobspec.impl
 
-import java.time.{Instant, ZoneId}
+import java.time.{ Instant, ZoneId }
 
-import dcos.metronome.model.{ConcurrencyPolicy, CronSpec, ScheduleSpec}
+import dcos.metronome.model.{ ConcurrencyPolicy, CronSpec, ScheduleSpec }
 import dcos.metronome.utils.test.Mockito
-import org.scalatest.{FunSuite, GivenWhenThen, Matchers}
+import org.scalatest.{ FunSuite, GivenWhenThen, Matchers }
 
 import scala.concurrent.duration._
 


### PR DESCRIPTION
Summary:
Removed unnecessary permission checking for every active run and instead of checking it only once for the `jobSpec`

JIRA issues:  COPS-5143
