### PR TITLE
Do not upgrade Metronome on EE.

### DIFF
--- a/ci/pipeline
+++ b/ci/pipeline
@@ -123,7 +123,6 @@ def build(logFileName: String): utils.SemVer = {
 
 def updateDcos(artifact: awsClient.Artifact, version: utils.SemVer) = utils.stage("Package") {
   upgrade.updateMetronome(artifact.downloadUrl, artifact.sha1, s"Update Metronome to $version")
-  upgrade.updateMetronomeEE(artifact.downloadUrl, artifact.sha1, s"Update Metronome to $version")
 }
 
 /**
@@ -148,8 +147,8 @@ def jenkins(): Unit = {
     val version = build(logFileName)
     val maybeArtifact = uploadTarballToS3(s"builds/$version")
     maybeArtifact.foreach { artifact =>
-          updateDcos(artifact, version)
-      }
+      updateDcos(artifact, version)
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
The Metronome package was removed on EE.