### PR TITLE
Fold schedules into job spec model.

### DIFF
--- a/api/src/main/resources/public/api/v1/examples/job.json
+++ b/api/src/main/resources/public/api/v1/examples/job.json
@@ -5,6 +5,7 @@
     "location": "olympus",
     "owner": "zeus"
   },
+  "schedules": [],
   "run": {
     "artifacts": [
       {

--- a/api/src/main/resources/public/api/v1/examples/job_list.json
+++ b/api/src/main/resources/public/api/v1/examples/job_list.json
@@ -3,6 +3,7 @@
     "description": "Send summary every day",
     "id": "prod.email.summary",
     "labels": {},
+    "schedules": [],
     "run": {
       "artifacts": [],
       "cmd": "sendSummary",

--- a/api/src/main/resources/public/api/v1/jobs.raml
+++ b/api/src/main/resources/public/api/v1/jobs.raml
@@ -11,7 +11,7 @@ get:
 
         - <code>activeRuns</code> embed all current active runs of this job<br/>
 
-        - <code>schedules</code> embed all schedules assigned to this job<br/>
+        - <code>schedules</code> DEPRECATED! embed all schedules assigned to this job<br/>
 
         - <code>history</code> embed history information, attached to this job<br/>
 

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -27,10 +27,7 @@
       }
     },
     "schedules": {
-      "type": "array",
-      "items": {
-        "$ref": "schedulespec.schema.json"
-      }
+      "type": "array"
     },
     "run": {
       "type": "object",

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -5,6 +5,40 @@
       "type": "string",
       "pattern": "^([a-z0-9]+(\\-[a-z0-9]+)*)(\\.([a-z0-9]+(\\-[a-z0-9]+)*))*$",
       "minLength": 1
+    },
+    "schedule": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/pathType",
+          "description": "Unique identifier for the job schedule of a string with at least 1 character and may only contain digits (`0-9`), dashes (`-`), and lowercase letters (`a-z`). The id may not begin or end with a dash."
+        },
+        "cron": {
+          "type": "string",
+          "description": "Cron based schedule string."
+        },
+        "timezone": {
+          "type": "string",
+          "description": "IANA based time zone string. See http://www.iana.org/time-zones for a list of available time zones."
+        },
+        "startingDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "The number of seconds until the job is still considered valid to start."
+        },
+        "concurrencyPolicy": {
+          "type": "string",
+          "enum": ["ALLOW", "FORBID"],
+          "description": "Defines the behavior if a job is started, before the current job has finished. ALLOW will launch a new job, even if there is an existing run."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Defines if the schedule is enabled or not."
+        }
+      },
+      "required": [
+        "id", "cron"
+      ]
     }
   },
   "type": "object",
@@ -27,7 +61,8 @@
       }
     },
     "schedules": {
-      "type": "array"
+      "type": "array",
+      "items": { "$ref": "#/definitions/schedule" }
     },
     "run": {
       "type": "object",

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -26,6 +26,12 @@
         "type": "string"
       }
     },
+    "schedules": {
+      "type": "array",
+      "items": {
+        "$ref": "schedulespec.schema.json"
+      }
+    },
     "run": {
       "type": "object",
       "additionalProperties": false,

--- a/api/src/main/scala/dcos/metronome/api/Binders.scala
+++ b/api/src/main/scala/dcos/metronome/api/Binders.scala
@@ -49,7 +49,6 @@ object Binders {
         params: Map[String, scala.collection.Seq[String]]
     ): Option[Either[String, Set[Embed]]] = {
       val embeds = params.getOrElse(key, Seq.empty).flatMap(_.split(","))
-      // TODO: marks schedules as deprecated.
       val valid = embeds.flatMap(Embed.names.get)
       if (valid.size != embeds.size)
         Some(Left(s"Unknown embed options. Valid options are: ${Embed.names.keys.mkString(", ")}"))

--- a/api/src/main/scala/dcos/metronome/api/Binders.scala
+++ b/api/src/main/scala/dcos/metronome/api/Binders.scala
@@ -49,6 +49,7 @@ object Binders {
         params: Map[String, scala.collection.Seq[String]]
     ): Option[Either[String, Set[Embed]]] = {
       val embeds = params.getOrElse(key, Seq.empty).flatMap(_.split(","))
+      // TODO: marks schedules as deprecated.
       val valid = embeds.flatMap(Embed.names.get)
       if (valid.size != embeds.size)
         Some(Left(s"Unknown embed options. Valid options are: ${Embed.names.keys.mkString(", ")}"))

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -269,7 +269,8 @@ package object models {
     (__ \ "description").formatNullable[String] ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
     (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
-    (__ \ "run").format[JobRunSpec])(JobSpec.apply(_, _, _, Seq.empty, _), s => (s.id, s.description, s.labels, s.run))
+    (__ \ "run")
+      .format[JobRunSpec])(JobSpec.apply(_, _, _, _, _), s => (s.id, s.description, s.labels, s.schedules, s.run))
 
   implicit lazy val TaskIdFormat: Format[Task.Id] = Format(
     Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -268,6 +268,7 @@ package object models {
   implicit lazy val JobSpecFormat: Format[JobSpec] = ((__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
+    (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
     (__ \ "run").format[JobRunSpec])(JobSpec.apply(_, _, _, Seq.empty, _), s => (s.id, s.description, s.labels, s.run))
 
   implicit lazy val TaskIdFormat: Format[Task.Id] = Format(

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobScheduleControllerTest.scala
@@ -39,6 +39,10 @@ class JobScheduleControllerTest
       status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
       contentAsJson(response) mustBe schedule1Json
+
+      And("The spec must include the new schedule")
+      val fetchedSpec = route(app, FakeRequest(GET, s"/v1/jobs/$specId")).get
+      (contentAsJson(fetchedSpec) \ "schedules" \ 0).get mustBe schedule1Json
     }
 
     "create a job schedule with timezone" in {
@@ -77,7 +81,7 @@ class JobScheduleControllerTest
       contentAsJson(response) mustBe schedule3Json
     }
 
-    "can not create a job schedule with the same id" in {
+    "cannot create a job schedule with the same id" in {
       Given("A job")
       route(app, FakeRequest(POST, "/v1/jobs").withJsonBody(jobSpecJson)).get.futureValue
       route(app, FakeRequest(POST, s"/v1/jobs/$specId/schedules").withJsonBody(schedule1Json)).get.futureValue
@@ -91,7 +95,7 @@ class JobScheduleControllerTest
       contentAsString(response) must include("A schedule with id id1 already exists")
     }
 
-    "can not create more than one job schedule per job (only temporary limitation)" in {
+    "cannot create more than one job schedule per job (only temporary limitation)" in {
       Given("A job")
       route(app, FakeRequest(POST, "/v1/jobs").withJsonBody(jobSpecJson)).get.futureValue
       route(app, FakeRequest(POST, s"/v1/jobs/$specId/schedules").withJsonBody(schedule1Json)).get.futureValue

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -145,6 +145,7 @@ class JobSpecControllerTest
 
       Then("The schedules get ignored")
       val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSchedule)).get
+      println(s"Content: ${contentAsString(response)}")
       status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
       contentAsJson(response) mustBe jobSpec2Json

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -137,18 +137,17 @@ class JobSpecControllerTest
       contentType(response) mustBe Some("application/json")
     }
 
-    "ignore given schedules when sending a valid job spec with schedules" in {
+    "*not* ignore given schedules when sending a valid job spec with schedules" in {
       Given("No job")
 
       When("A job spec with schedules is sent")
       val jobSpecWithSchedule = Json.toJson(jobSpec2.copy(schedules = Seq(schedule1)))
 
-      Then("The schedules get ignored")
+      Then("The schedules are added")
       val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobSpecWithSchedule)).get
-      println(s"Content: ${contentAsString(response)}")
       status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
-      contentAsJson(response) mustBe jobSpec2Json
+      contentAsJson(response) mustBe jobSpecWithSchedule
     }
 
     "indicate a problem when sending invalid json" in {

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Next
 
+* [DCOS_OSS-5970](https://jira.d2iq.com/browse/DCOS_OSS-5970) Schedules can be defined with job spec creation. They are always returned. `èmbed=schedules` has been deprecated.
+
 # 0.6.x
 
 * [D2IQ-69445](https://jira.d2iq.com/browse/D2IQ-69445) Introduce `/leader` endpoint to query the current Metronome leader address in HA mode.

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
@@ -12,7 +12,7 @@ case class JobInfo(
     description: Option[String],
     labels: Map[String, String],
     run: JobRunSpec,
-    schedules: Option[Seq[ScheduleSpec]],
+    schedules: Seq[ScheduleSpec],
     activeRuns: Option[Iterable[StartedJobRun]],
     history: Option[JobHistory],
     historySummary: Option[JobHistorySummary]
@@ -35,7 +35,7 @@ object JobInfo {
 
   def apply(
       spec: JobSpec,
-      schedules: Option[Seq[ScheduleSpec]],
+      schedules: Seq[ScheduleSpec],
       runs: Option[Iterable[StartedJobRun]],
       history: Option[JobHistory],
       summary: Option[JobHistorySummary]

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImpl.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImpl.scala
@@ -29,7 +29,7 @@ class JobInfoServiceImpl(
       val historyOption = if (embed(Embed.History)) historyData else None
       val summaryOption = if (embed(Embed.HistorySummary)) historyData.map(JobHistorySummary.apply) else None
       await(jobSpecService.getJobSpec(jobSpecId)).filter(selector.matches).map { jobSpec =>
-        JobInfo(jobSpec, schedulesOption(jobSpec, embed), runOption, historyOption, summaryOption)
+        JobInfo(jobSpec, jobSpec.schedules, runOption, historyOption, summaryOption)
       }
     }
   }
@@ -62,11 +62,8 @@ class JobInfoServiceImpl(
       def summary(id: JobId): Option[JobHistorySummary] =
         if (embed(Embed.HistorySummary)) summaries.get(id).orElse(Some(JobHistorySummary.empty(id))) else None
       specs.map { spec =>
-        JobInfo(spec, schedulesOption(spec, embed), runs.get(spec.id), history(spec.id), summary(spec.id))
+        JobInfo(spec, spec.schedules, runs.get(spec.id), history(spec.id), summary(spec.id))
       }
     }
-  }
-  private[this] def schedulesOption(spec: JobSpec, embed: Set[Embed]) = {
-    if (embed(Embed.Schedules)) Some(spec.schedules) else None
   }
 }

--- a/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
@@ -25,7 +25,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("No Job is returned")
     result1 should be(defined)
-    result1.get.schedules should be(empty)
+    result1.get.schedules should have size 2
     result1.get.activeRuns should be(empty)
   }
 
@@ -42,7 +42,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
     result1.get.activeRuns should be(defined)
   }
 
-  test("Empty embed options will not render embedded info") {
+  test("Empty embed options will only render schedules") {
     Given("A repo with 2 specs and 2 runs")
     val f = new Fixture
 
@@ -51,7 +51,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("The extended info is empty")
     result1 should have size 2
-    result1.foreach(_.schedules should be(empty))
+    result1.foreach(_.schedules should not be(empty))
     result1.foreach(_.activeRuns should be(empty))
   }
 
@@ -75,7 +75,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("The extended info is rendered for active runs")
     result1 should have size 2
-    result1.foreach(_.schedules should be(empty))
+    result1.foreach(_.schedules should have size 2)
     result1.foreach(_.activeRuns.get should have size 1)
   }
 
@@ -101,7 +101,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("The extended info is rendered for active runs")
     result should have size 2
-    result.foreach(_.schedules should be(empty))
+    result.foreach(_.schedules should have size 2)
     result.foreach(_.activeRuns should be(empty))
     result.map(_.history.get).toSet should be(Set(f.history1, f.history2))
   }
@@ -115,7 +115,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("The extended info is rendered for active runs")
     result should have size 2
-    result.foreach(_.schedules should be(empty))
+    result.foreach(_.schedules should have size 2)
     result.foreach(_.activeRuns should be(empty))
     result.map(_.historySummary.get).toSet should be(Set(f.historySummary1, f.historySummary2))
   }

--- a/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
@@ -35,11 +35,10 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     When("The job info is fetched")
     val result1 =
-      f.jobInfoService.selectJob(f.spec1.id, JobSpecSelector.all, Set(Embed.ActiveRuns, Embed.Schedules)).futureValue
+      f.jobInfoService.selectJob(f.spec1.id, JobSpecSelector.all, Set(Embed.ActiveRuns)).futureValue
 
     Then("No Job is returned")
     result1 should be(defined)
-    result1.get.schedules should be(defined)
     result1.get.activeRuns should be(defined)
   }
 
@@ -85,11 +84,11 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
     val f = new Fixture
 
     When("The job info is fetched")
-    val result1 = f.jobInfoService.selectJobs(JobSpecSelector.all, Set(Embed.Schedules)).futureValue
+    val result1 = f.jobInfoService.selectJobs(JobSpecSelector.all, Set.empty).futureValue
 
     Then("The extended info is rendered for active runs")
     result1 should have size 2
-    result1.foreach(_.schedules.get should have size 2)
+    result1.foreach(_.schedules should have size 2)
     result1.foreach(_.activeRuns should be(empty))
   }
 

--- a/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobinfo/impl/JobInfoServiceImplTest.scala
@@ -51,7 +51,7 @@ class JobInfoServiceImplTest extends FunSuite with GivenWhenThen with ScalaFutur
 
     Then("The extended info is empty")
     result1 should have size 2
-    result1.foreach(_.schedules should not be(empty))
+    result1.foreach(_.schedules should not be (empty))
     result1.foreach(_.activeRuns should be(empty))
   }
 


### PR DESCRIPTION
Summary:
This patch allows to specify schedules when creating job specifications.
Schedules are always embedded in job spec queries.

JIRA issues: DCOS_OSS-5970