### PR TITLE
Define dependencies on job spec.

### DIFF
--- a/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
+++ b/api/src/main/resources/public/api/v0/schema/jobspec_v0.schema.json
@@ -18,6 +18,17 @@
       "type": "string",
       "description": "A description of this job."
     },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/definitions/pathType"
+          }
+        }
+      }
+    },
     "labels": {
       "type": "object",
       "description": "Attaching metadata to jobs can be useful to expose additional information to other services, so we added the ability to place labels on jobs (for example, you could label jobs staging and production to mark services by their position in the pipeline).",

--- a/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
+++ b/api/src/main/resources/public/api/v1/schema/jobspec.schema.json
@@ -53,6 +53,17 @@
       "type": "string",
       "description": "A description of this job."
     },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/definitions/pathType"
+          }
+        }
+      }
+    },
     "labels": {
       "type": "object",
       "description": "Attaching metadata to jobs can be useful to expose additional information to other services, so we added the ability to place labels on jobs (for example, you could label jobs staging and production to mark services by their position in the pipeline).",

--- a/api/src/main/scala/dcos/metronome/api/RestController.scala
+++ b/api/src/main/scala/dcos/metronome/api/RestController.scala
@@ -21,8 +21,6 @@ class RestController(cc: ControllerComponents) extends AbstractController(cc) {
 
     val schemaValidator = SchemaValidator()
 
-    final case class ValidationError(errorMsg: String) extends Exception(errorMsg, null)
-
     def json[A](implicit reader: Reads[A], schema: JsonSchema[A], validator: Validator[A]): BodyParser[A] = {
       jsonWith[A](identity)
     }

--- a/api/src/main/scala/dcos/metronome/api/RestController.scala
+++ b/api/src/main/scala/dcos/metronome/api/RestController.scala
@@ -21,6 +21,8 @@ class RestController(cc: ControllerComponents) extends AbstractController(cc) {
 
     val schemaValidator = SchemaValidator()
 
+    final case class ValidationError(errorMsg: String) extends Exception(errorMsg, null)
+
     def json[A](implicit reader: Reads[A], schema: JsonSchema[A], validator: Validator[A]): BodyParser[A] = {
       jsonWith[A](identity)
     }

--- a/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
@@ -26,8 +26,6 @@ class ScheduledJobSpecController(
 
   import ScheduledJobSpecController._
 
-  implicit val jobSpecValidator = JobSpec.validJobSpec(jobSpecService)
-
   def createJob =
     AuthorizedAction.async(validate.json[JobSpec]) { implicit request =>
       request.authorizedAsync(CreateRunSpec) { jobSpec =>

--- a/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
@@ -53,7 +53,7 @@ class ScheduledJobSpecController(
 object ScheduledJobSpecController {
   implicit lazy val JobSpecWithScheduleFormat: Format[JobSpec] = ((__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
-    (__ \ "dependencies" \\ "id").formatNullable[Seq[JobId]] ~
+    (__ \ "dependencies" \\ "id").formatNullable[Seq[JobId]].withDefault(JobSpec.DefaultDependencies) ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
     (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
     (__ \ "run").format[JobRunSpec])(JobSpec.apply, unlift(JobSpec.unapply))

--- a/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
@@ -53,7 +53,9 @@ class ScheduledJobSpecController(
 object ScheduledJobSpecController {
   implicit lazy val JobSpecWithScheduleFormat: Format[JobSpec] = ((__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
-    (__ \ "dependencies" \\ "id").formatNullable[Seq[JobId]].withDefault(JobSpec.DefaultDependencies) ~
+    (__ \ "dependencies")
+      .formatNullable[Seq[JobId]](api.v1.models.DependencyFormat)
+      .withDefault(JobSpec.DefaultDependencies) ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
     (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
     (__ \ "run").format[JobRunSpec])(JobSpec.apply, unlift(JobSpec.unapply))

--- a/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v0/controllers/ScheduledJobSpecController.scala
@@ -26,6 +26,8 @@ class ScheduledJobSpecController(
 
   import ScheduledJobSpecController._
 
+  implicit val jobSpecValidator = JobSpec.validJobSpec(jobSpecService)
+
   def createJob =
     AuthorizedAction.async(validate.json[JobSpec]) { implicit request =>
       request.authorizedAsync(CreateRunSpec) { jobSpec =>
@@ -51,6 +53,7 @@ class ScheduledJobSpecController(
 object ScheduledJobSpecController {
   implicit lazy val JobSpecWithScheduleFormat: Format[JobSpec] = ((__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
+    (__ \ "dependencies" \\ "id").formatNullable[Seq[JobId]] ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
     (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
     (__ \ "run").format[JobRunSpec])(JobSpec.apply, unlift(JobSpec.unapply))

--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
@@ -28,6 +28,8 @@ class JobSpecController(
 )(implicit ec: ExecutionContext)
     extends Authorization(cc, metrics, authenticator, authorizer, config) {
 
+  implicit val jobSpecValidator = JobSpec.validJobSpec(jobSpecService)
+
   def createJob =
     measured {
       AuthorizedAction.async(validate.json[JobSpec]) { implicit request =>

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -268,8 +268,12 @@ package object models {
 
   implicit lazy val JobSpecFormat: Format[JobSpec] = ((__ \ "id").format[JobId] ~
     (__ \ "description").formatNullable[String] ~
+    (__ \ "dependencies" \\ "id").formatNullable[Seq[JobId]] ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
-    (__ \ "run").format[JobRunSpec])(JobSpec.apply(_, _, _, Seq.empty, _), s => (s.id, s.description, s.labels, s.run))
+    (__ \ "run").format[JobRunSpec])(
+    JobSpec.apply(_, _, _, _, Seq.empty, _),
+    s => (s.id, s.description, s.dependencies, s.labels, s.run)
+  )
 
   implicit lazy val TaskIdFormat: Format[Task.Id] = Format(
     Reads.of[String](Reads.minLength[String](3)).map(Task.Id(_)),

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -267,7 +267,7 @@ package object models {
         .withDefault(JobRunSpec.DefaultNetworks))(JobRunSpec.apply, unlift(JobRunSpec.unapply))
 
   // A format for JobId that writes and object {"id": value} instead of a plain string.
-  private val DependencyFormat: Format[Seq[JobId]] = Format(
+  val DependencyFormat: Format[Seq[JobId]] = Format(
     Reads.seq((__ \ "id").read[JobId]).map(_.toVector),
     Writes.iterableWrites[JobId, Seq]((__ \ "id").write[JobId])
   )
@@ -276,7 +276,7 @@ package object models {
     (__ \ "description").formatNullable[String] ~
     (__ \ "dependencies").formatNullable[Seq[JobId]](DependencyFormat).withDefault(JobSpec.DefaultDependencies) ~
     (__ \ "labels").formatNullable[Map[String, String]].withDefault(Map.empty) ~
-    (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(Seq.empty) ~
+    (__ \ "schedules").formatNullable[Seq[ScheduleSpec]].withDefault(JobSpec.DefaultSchedules) ~
     (__ \ "run")
       .format[JobRunSpec])(JobSpec.apply, unlift(JobSpec.unapply))
 

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -5,7 +5,7 @@ import dcos.metronome.api.v1.models._
 import dcos.metronome.api._
 import dcos.metronome.model._
 import mesosphere.marathon.core.plugin.PluginManager
-import org.scalatest.{BeforeAndAfter, GivenWhenThen}
+import org.scalatest.{AppendedClues, BeforeAndAfter, GivenWhenThen}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatestplus.play.PlaySpec
@@ -17,6 +17,7 @@ import play.api.test.Helpers._
 class JobSpecControllerTest
     extends PlaySpec
     with OneAppPerTestWithComponents[MockApiComponents]
+    with AppendedClues
     with GivenWhenThen
     with ScalaFutures
     with BeforeAndAfter {
@@ -451,7 +452,7 @@ class JobSpecControllerTest
       Then("The job is created")
       status(response) mustBe CREATED
       contentType(response) mustBe Some("application/json")
-      contentAsJson(response) mustBe jobBWithDependency
+      contentAsJson(response) mustBe jobBWithDependencyJson
     }
   }
 
@@ -774,9 +775,9 @@ class JobSpecControllerTest
   }
   val cmdGpuJobJson = Json.toJson(cmdGpuJob)
 
-  val jobA = spec("A")
+  val jobA = spec("a")
   val jobAJson = Json.toJson(jobA)
-  val jobBWithDependency = spec("B").copy(dependencies = Seq(jobA.id))
+  val jobBWithDependency = spec("b").copy(dependencies = Seq(jobA.id))
   val jobBWithDependencyJson = Json.toJson(jobBWithDependency)
 
   before {

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -454,6 +454,18 @@ class JobSpecControllerTest
       contentType(response) mustBe Some("application/json")
       contentAsJson(response) mustBe jobBWithDependencyJson
     }
+
+    "fail with a job with unknown dependency" in {
+      Given("Job A does not exist")
+
+      When("A job B with dependency on job A is posted")
+      val response = route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobBWithDependencyJson)).get
+
+      Then("The job is created")
+      status(response) mustBe UNPROCESSABLE_ENTITY
+      contentType(response) mustBe Some("application/json")
+      contentAsJson(response) \ "message" mustBe JsDefined(JsString("Dependencies contain unknown jobs. unknown=[a]"))
+    }
   }
 
   "GET /jobs" should {

--- a/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/controllers/JobSpecControllerTest.scala
@@ -441,7 +441,7 @@ class JobSpecControllerTest
       contentType(response) mustBe Some("application/json")
     }
 
-    "creates a job with dependencies" in {
+    "create a job with dependencies" in {
       Given("Job A")
       route(app, FakeRequest(POST, s"/v1/jobs").withJsonBody(jobAJson)).get.futureValue
 

--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,7 @@ lazy val api = (project in file("api"))
   )
 
 lazy val jobs = (project in file("jobs"))
+  .enablePlugins(PB)
   .settings(
     version := {
       import sys.process._

--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,7 @@ lazy val jobs = (project in file("jobs"))
       Dependencies.akka,
       Dependencies.akkaSlf4j,
       Dependencies.caffeine,
+      Dependencies.usiCommons,
       Dependencies.Test.scalatest,
       Dependencies.Test.akkaTestKit,
       Dependencies.Test.mockito,

--- a/jobs/src/main/protobuf/metronome.proto
+++ b/jobs/src/main/protobuf/metronome.proto
@@ -240,6 +240,11 @@ message JobSpec {
   }
 
   optional RunSpec run = 6;
+
+  message Dependency {
+    optional string id = 1;
+  }
+  repeated Dependency dependencies = 20;
 }
 
 message NetworkDefinition {

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
@@ -10,6 +10,7 @@ import dcos.metronome.model._
 case class JobInfo(
     id: JobId,
     description: Option[String],
+    dependencies: Seq[JobId],
     labels: Map[String, String],
     run: JobRunSpec,
     schedules: Seq[ScheduleSpec],
@@ -40,6 +41,6 @@ object JobInfo {
       history: Option[JobHistory],
       summary: Option[JobHistorySummary]
   ): JobInfo = {
-    JobInfo(spec.id, spec.description, spec.labels, spec.run, schedules, runs, history, summary)
+    JobInfo(spec.id, spec.description, spec.dependencies, spec.labels, spec.run, schedules, runs, history, summary)
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecService.scala
@@ -55,7 +55,7 @@ trait JobSpecService {
     * Process a modification in a transaction. No other operation can be performed during the this transaction.
     *
     * @param updater The update method.
-    * @return the resulting job specification of the update.
+    * @return the resulting job specification of the update or none if no update was applied.
     */
-  def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[JobSpec]
+  def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[Option[JobSpec]]
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecService.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecService.scala
@@ -1,6 +1,7 @@
 package dcos.metronome
 package jobspec
 
+import dcos.metronome.jobspec.impl.JobSpecServiceActor.Modification
 import dcos.metronome.model.{JobId, JobSpec}
 
 import scala.concurrent.Future
@@ -50,4 +51,11 @@ trait JobSpecService {
     */
   def listJobSpecs(filter: JobSpec => Boolean): Future[Iterable[JobSpec]]
 
+  /**
+    * Process a modification in a transaction. No other operation can be performed during the this transaction.
+    *
+    * @param updater The update method.
+    * @return the resulting job specification of the update.
+    */
+  def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[JobSpec]
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
@@ -183,11 +183,13 @@ class JobSpecServiceActor(
 object JobSpecServiceActor {
 
   //crud messages
+  sealed trait Message
+  sealed trait Modification extends Message
   case class ListJobSpecs(filter: JobSpec => Boolean)
   case class GetJobSpec(id: JobId)
-  case class CreateJobSpec(jobSpec: JobSpec)
-  case class UpdateJobSpec(id: JobId, change: JobSpec => JobSpec)
-  case class DeleteJobSpec(id: JobId)
+  case class CreateJobSpec(jobSpec: JobSpec) extends Modification
+  case class UpdateJobSpec(id: JobId, change: JobSpec => JobSpec) extends Modification
+  case class DeleteJobSpec(id: JobId) extends Modification
 
   def props(
       repo: Repository[JobId, JobSpec],

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
@@ -46,5 +46,8 @@ class JobSpecServiceDelegate(config: JobSpecConfig, actorRef: ActorRef, metrics:
       actorRef.ask(DeleteJobSpec(id)).mapTo[JobSpec]
     }
 
-  override def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[JobSpec] = ???
+  override def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[Option[JobSpec]] =
+    updateJobSpecTimeMetric {
+      actorRef.ask(Transaction(updater)).mapTo[Option[JobSpec]]
+    }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
@@ -4,6 +4,7 @@ package jobspec.impl
 import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
+import com.mesosphere.usi.async.ExecutionContexts
 import dcos.metronome.jobspec.impl.JobSpecServiceActor._
 import dcos.metronome.jobspec.{JobSpecConfig, JobSpecService}
 import dcos.metronome.model.{JobId, JobSpec}
@@ -48,6 +49,6 @@ class JobSpecServiceDelegate(config: JobSpecConfig, actorRef: ActorRef, metrics:
 
   override def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[Option[JobSpec]] =
     updateJobSpecTimeMetric {
-      actorRef.ask(Transaction(updater)).mapTo[Option[JobSpec]]
+      actorRef.ask(Transaction(updater)).mapTo[JobSpec].map(Option.apply)(ExecutionContexts.callerThread)
     }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceDelegate.scala
@@ -45,4 +45,6 @@ class JobSpecServiceDelegate(config: JobSpecConfig, actorRef: ActorRef, metrics:
     deleteJobSpecTimeMetric {
       actorRef.ask(DeleteJobSpec(id)).mapTo[JobSpec]
     }
+
+  override def transaction(updater: Seq[JobSpec] => Option[Modification]): Future[JobSpec] = ???
 }

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -1,17 +1,21 @@
 package dcos.metronome
 package model
 
-import com.wix.accord.Validator
+import com.wix.accord.{NullSafeValidator, Validator}
 import com.wix.accord.dsl._
+import dcos.metronome.jobspec.JobSpecService
 import dcos.metronome.model.JobRunSpec._
 import dcos.metronome.utils.glue.MarathonConversions
 import mesosphere.marathon.api.v2.Validation._
 import mesosphere.marathon
-import mesosphere.marathon.plugin.{ApplicationSpec, NetworkSpec, Secret, VolumeSpec, VolumeMountSpec}
+import mesosphere.marathon.plugin.{ApplicationSpec, NetworkSpec, Secret, VolumeMountSpec, VolumeSpec}
+
+import scala.concurrent.Await
 
 case class JobSpec(
     id: JobId,
     description: Option[String] = JobSpec.DefaultDescription,
+    dependencies: Option[Seq[JobId]] = JobSpec.DefaultDependencies,
     labels: Map[String, String] = JobSpec.DefaultLabels,
     schedules: Seq[ScheduleSpec] = JobSpec.DefaultSchedule,
     run: JobRunSpec = JobSpec.DefaultRunSpec
@@ -29,14 +33,36 @@ case class JobSpec(
 
 object JobSpec {
   val DefaultDescription = None
+  val DefaultDependencies = Option.empty[Seq[JobId]]
   val DefaultLabels = Map.empty[String, String]
   val DefaultSchedule = Seq.empty[ScheduleSpec]
   val DefaultRunSpec = JobRunSpec()
 
-  implicit lazy val validJobSpec: Validator[JobSpec] = validator[JobSpec] { jobSpec =>
+  import com.wix.accord.ViolationBuilder._
+
+  private def unique[T]: Validator[Seq[T]] = new NullSafeValidator[Seq[T]](
+    test = col => col.size == col.toSet.size,
+    failure = _ -> s"has double entries"
+  )
+
+  def acyclic[JobId]: Validator[Seq[JobId]] = new NullSafeValidator[Seq[JobId]](
+    test = _ => false, // TODO: check if the dependencies are cyclic.
+    failure = _ -> "is not acyclic"
+  )
+
+  def validJobSpec(jobSpecService: JobSpecService): Validator[JobSpec] = validator[JobSpec] { jobSpec =>
+
+    def exist: Validator[Seq[JobId]] = new NullSafeValidator[Seq[JobId]](
+      test = ids => ids.exists(id => Await.result(jobSpecService.getJobSpec(id), ???).isEmpty),
+      failure = _ -> "has dependencies that do not exist" // TODO: specify which dependencies.
+    )
+
     jobSpec.id is valid
     jobSpec.schedules is every(valid)
     jobSpec.run is valid
     jobSpec.schedules has size <= 1 // FIXME: we will support only one schedule in v1
+    jobSpec.dependencies.each is unique[JobId]
+    jobSpec.dependencies.each should exist
+    jobSpec.dependencies.each is acyclic
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -17,7 +17,7 @@ case class JobSpec(
     description: Option[String] = JobSpec.DefaultDescription,
     dependencies: Seq[JobId] = JobSpec.DefaultDependencies,
     labels: Map[String, String] = JobSpec.DefaultLabels,
-    schedules: Seq[ScheduleSpec] = JobSpec.DefaultSchedule,
+    schedules: Seq[ScheduleSpec] = JobSpec.DefaultSchedules,
     run: JobRunSpec = JobSpec.DefaultRunSpec
 ) extends ApplicationSpec {
   def schedule(id: String): Option[ScheduleSpec] = schedules.find(_.id == id)
@@ -35,7 +35,7 @@ object JobSpec {
   val DefaultDescription = None
   val DefaultDependencies = Seq.empty[JobId]
   val DefaultLabels = Map.empty[String, String]
-  val DefaultSchedule = Seq.empty[ScheduleSpec]
+  val DefaultSchedules = Seq.empty[ScheduleSpec]
   val DefaultRunSpec = JobRunSpec()
 
   import com.wix.accord.ViolationBuilder._

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -71,7 +71,7 @@ object JobSpec {
 
     // Validate that graph is acyclic
 
-    /* Assumption: The current state allSpecs has now cycles.
+    /* Assumption: The current state allSpecs have no cycles.
      Thus:
         - if job spec A is new we cannot create a DAG with cycles since A has no incoming vertices.
         - if job spec A is updated we check if we can find a path from one of A's dependencies to A.

--- a/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
+++ b/jobs/src/main/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshaller.scala
@@ -44,6 +44,7 @@ object JobSpecConversions {
         .addAllLabels(jobSpec.labels.toProto.asJava)
         .setRun(jobSpec.run.toProto)
         .addAllSchedules(jobSpec.schedules.toProto.asJava)
+        .addAllDependencies(jobSpec.dependencies.toProto.asJava)
 
       jobSpec.description.foreach(builder.setDescription)
 
@@ -60,6 +61,7 @@ object JobSpecConversions {
       JobSpec(
         id = JobId(proto.getId),
         description = description,
+        dependencies = proto.getDependenciesList.asScala.toModel,
         labels = proto.getLabelsList.asScala.toModel,
         schedules = proto.getSchedulesList.asScala.toModel,
         run = proto.getRun.toModel
@@ -118,6 +120,21 @@ object JobSpecConversions {
         )
       }.toList
     }
+  }
+
+  implicit class DependenciesToProto(val dependencies: Seq[JobId]) extends AnyVal {
+    def toProto: Seq[Protos.JobSpec.Dependency] =
+      dependencies.map { dependency =>
+        Protos.JobSpec.Dependency
+          .newBuilder()
+          .setId(dependency.toString)
+          .build
+      }
+  }
+
+  implicit class ProtoToDependencies(val dependencies: mutable.Buffer[Protos.JobSpec.Dependency]) extends AnyVal {
+    def toModel: Seq[JobId] =
+      dependencies.map { dependency => JobId(dependency.getId) }.toVector
   }
 }
 

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
@@ -66,19 +66,22 @@ object JobSpecServiceFixture {
         }
       }
 
-      override def transaction(updater: Seq[JobSpec] => Option[JobSpecServiceActor.Modification]): Future[Option[JobSpec]] = {
+      override def transaction(
+          updater: Seq[JobSpec] => Option[JobSpecServiceActor.Modification]
+      ): Future[Option[JobSpec]] = {
         try {
           updater(specs.values.toVector) match {
             case None => successful(None)
-            case Some(modification) => modification match {
-              case JobSpecServiceActor.CreateJobSpec(jobSpec) => createJobSpec(jobSpec).map(Option.apply)
-              case JobSpecServiceActor.UpdateJobSpec(id, change) => updateJobSpec(id, change).map(Option.apply)
-              case JobSpecServiceActor.DeleteJobSpec(id) => deleteJobSpec(id).map(Option.apply)
-            }
+            case Some(modification) =>
+              modification match {
+                case JobSpecServiceActor.CreateJobSpec(jobSpec) => createJobSpec(jobSpec).map(Option.apply)
+                case JobSpecServiceActor.UpdateJobSpec(id, change) => updateJobSpec(id, change).map(Option.apply)
+                case JobSpecServiceActor.DeleteJobSpec(id) => deleteJobSpec(id).map(Option.apply)
+              }
           }
-          } catch {
-            case ex: Throwable => failed(ex)
-          }
+        } catch {
+          case ex: Throwable => failed(ex)
+        }
       }
     }
 }

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceFixture.scala
@@ -63,5 +63,7 @@ object JobSpecServiceFixture {
           case None => failed(JobSpecDoesNotExist(id))
         }
       }
+
+      override def transaction(updater: Seq[JobSpec] => Option[JobSpecServiceActor.Modification]): Future[JobSpec] = ???
     }
 }

--- a/jobs/src/test/scala/dcos/metronome/model/JobSpecTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/model/JobSpecTest.scala
@@ -1,0 +1,49 @@
+package dcos.metronome
+package model
+
+import dcos.metronome.model.JobSpec.ValidationError
+import dcos.metronome.utils.test.Mockito
+import org.scalatest.{FunSuite, GivenWhenThen, Matchers}
+
+class JobSpecTest extends FunSuite with Matchers with Mockito with GivenWhenThen {
+
+  test("Job spec with no dependencies is valid") {
+    val f = Fixture()
+    val jobSpecA = JobSpec(id = JobId("a"), run = f.runSpec)
+
+    JobSpec.validateDependencies(jobSpecA, Seq.empty) // does not throw
+  }
+
+  test("New job spec with dependencies is valid") {
+    val f = Fixture()
+    val jobSpecA = JobSpec(id = JobId("a"), run = f.runSpec)
+    val jobSpecB = JobSpec(id = JobId("b"), run = f.runSpec, dependencies = Seq(jobSpecA.id))
+
+    JobSpec.validateDependencies(jobSpecB, Seq(jobSpecA)) // does not throw
+  }
+
+  test("New job spec with an unknown dependency is invalid") {
+    val f = Fixture()
+    val jobSpecA = JobSpec(id = JobId("a"), run = f.runSpec)
+    val jobSpecB = JobSpec(id = JobId("b"), run = f.runSpec, dependencies = Seq(JobId("unknown.job"), jobSpecA.id))
+
+    the[ValidationError] thrownBy {
+      JobSpec.validateDependencies(jobSpecB, Seq(jobSpecA))
+    } should have message "Dependencies contain unknown jobs. unknown=[unknown.job]"
+  }
+
+  test("Updated job spec introduces a cycle and is invalid") {
+    val f = Fixture()
+    val jobSpecA = JobSpec(id = JobId("a"), run = f.runSpec)
+    val jobSpecB = JobSpec(id = JobId("b"), run = f.runSpec, dependencies = Seq(jobSpecA.id))
+    val updatedJobSpecA = jobSpecA.copy(dependencies = Seq(jobSpecB.id))
+
+    the[ValidationError] thrownBy {
+      JobSpec.validateDependencies(updatedJobSpecA, Seq(jobSpecA, jobSpecB))
+    } should have message "Dependencies have a cycle."
+  }
+
+  case class Fixture() {
+    val runSpec = JobRunSpec(cmd = Some("sleep 1000"))
+  }
+}

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -115,9 +115,12 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with ScalaCheckProper
     )
   }
 
+  val jobIdGen = Gen.listOf(nonEmptyAlphaStrGen).map(s => JobId(s))
+
   val jobSpecGen = for {
-    id <- Gen.listOf(nonEmptyAlphaStrGen).map(s => JobId(s))
+    id <- jobIdGen
     description <- Gen.option(nonEmptyAlphaStrGen)
+    //dependencies <- Gen.listOf(jobIdGen)
     labels <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen))
     schedules <- Gen.listOf(for {
       id <- nonEmptyAlphaStrGen
@@ -128,7 +131,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with ScalaCheckProper
       enabled <- booleanGen
     } yield ScheduleSpec(id, cron, timeZone, startingDeadline, concurrencyPolicy, enabled))
     run <- jobRunSpecGen
-  } yield JobSpec(id, description, labels, schedules, run)
+  } yield JobSpec(id, description, Seq.empty, labels, schedules, run) // TODO: serialize dependencies
 
   implicit val jobSpecArbitrary = Arbitrary(jobSpecGen)
 

--- a/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/repository/impl/kv/marshaller/JobSpecMarshallerTest.scala
@@ -120,7 +120,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with ScalaCheckProper
   val jobSpecGen = for {
     id <- jobIdGen
     description <- Gen.option(nonEmptyAlphaStrGen)
-    //dependencies <- Gen.listOf(jobIdGen)
+    dependencies <- Gen.listOf(jobIdGen)
     labels <- Gen.mapOf(Gen.zip(nonEmptyAlphaStrGen, nonEmptyAlphaStrGen))
     schedules <- Gen.listOf(for {
       id <- nonEmptyAlphaStrGen
@@ -131,7 +131,7 @@ class JobSpecMarshallerTest extends FunSuite with Matchers with ScalaCheckProper
       enabled <- booleanGen
     } yield ScheduleSpec(id, cron, timeZone, startingDeadline, concurrencyPolicy, enabled))
     run <- jobRunSpecGen
-  } yield JobSpec(id, description, Seq.empty, labels, schedules, run) // TODO: serialize dependencies
+  } yield JobSpec(id, description, dependencies, labels, schedules, run) // TODO: serialize dependencies
 
   implicit val jobSpecArbitrary = Arbitrary(jobSpecGen)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
     val JsonValidate = "0.9.4"
     val MoultingYaml = "0.4.0"
     val Caffeine = "2.6.2"
-    val UsiTestUtils = "0.1.50"
+    val Usi = "0.1.54"
     val AkkaHttp = "10.1.11"
   }
 
@@ -47,6 +47,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-http-xml" % V.AkkaHttp,
     "de.heikoseeberger" %% "akka-http-play-json" % "1.31.0"
   )
+  val usiCommons = "com.mesosphere.usi" %% "commons" % V.Usi
 
   object Test {
     val scalatest = "org.scalatest" %% "scalatest" % V.ScalaTest % "test"
@@ -56,7 +57,7 @@ object Dependencies {
     val mockito = "org.mockito" % "mockito-core" % V.Mockito % "test"
 
     val usiTestUtils =
-      "com.mesosphere.usi" %% "test-utils" % V.UsiTestUtils % "test" exclude ("org.apache.zookeeper", "zookeeper")
+      "com.mesosphere.usi" %% "test-utils" % V.Usi % "test" exclude ("org.apache.zookeeper", "zookeeper")
 
   }
 }


### PR DESCRIPTION
Summary:
This patch introduces the `dependencies` field to job specs. Job specs
cannot define dependencies on parents.

JIRA issues: DCOS_OSS-5971