### PR TITLE
Validate job spec updates.

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/controllers/JobSpecController.scala
@@ -89,7 +89,7 @@ class JobSpecController(
 
               f.recover {
                 case JobSpecDoesNotExist(_) => NotFound(UnknownJob(id))
-                case JobSpec.DependencyConflict(msg) => Conflict(ErrorDetail(msg))
+                case ex: JobSpec.DependencyConflict => Conflict(ErrorDetail(ex.getMessage))
               }
           }
         }

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
@@ -65,7 +65,7 @@ class JobSpecServiceActor(
   def updateJobSpec(id: JobId, change: JobSpec => JobSpec): Unit = {
     withJob(id) { old =>
       noChangeInFlight(old) {
-        validJobSpec(old) { // TODO: this must be the job spec after the update. See https://jira.d2iq.com/browse/D2IQ-70391
+        validJobSpec(change(old)) {
           persistenceActor(id) ! JobSpecPersistenceActor.Update(change, sender())
         }
       }

--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -53,7 +53,8 @@ object JobSpec {
     }
 
   final case class ValidationError(errorMsg: String) extends Exception(errorMsg, null)
-  final case class DependencyConflict(errorMsg: String) extends Exception(errorMsg, null)
+  final case class DependencyConflict(parentId: JobId, children: Seq[JobId])
+      extends Exception(s"There are jobs with a dependency on $parentId. children=[${children.mkString(", ")}]", null)
 
   def validateDependencies(jobSpec: JobSpec, allSpecs: Seq[JobSpec]): Unit = {
     val index = allSpecs.map(s => s.id -> s).toMap
@@ -110,7 +111,7 @@ object JobSpec {
     // Validate deleted job spec is not a dependency.
     if (allSpecs.exists(_.dependencies.contains(jobId))) {
       val children = allSpecs.filter(_.dependencies.contains(jobId)).map(_.id)
-      throw DependencyConflict(s"There are jobs with a dependency on $jobId. children=[${children.mkString(", ")}]")
+      throw DependencyConflict(jobId, children)
     }
   }
 }


### PR DESCRIPTION
Summary:
Job spec updates were not validated for possible dependency cycles. This
patch introduces the same validation already used by job spec creation.

JIRA issues: D2IQ-70391