### PR TITLE
Execute dependent job when all dependencies finished.

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecModule.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/JobSpecModule.scala
@@ -6,6 +6,7 @@ import java.time.Clock
 import akka.actor.ActorSystem
 import dcos.metronome.jobrun.JobRunService
 import dcos.metronome.jobspec.impl.{
+  JobSpecDependencyActor,
   JobSpecPersistenceActor,
   JobSpecSchedulerActor,
   JobSpecServiceActor,
@@ -28,9 +29,10 @@ class JobSpecModule(
 
   private[this] def persistenceActor(id: JobId) = JobSpecPersistenceActor.props(id, jobSpecRepository, metrics)
   private[this] def scheduleActor(jobSpec: JobSpec) = JobSpecSchedulerActor.props(jobSpec, clock, runService)
+  private[this] def dependencyActor(jobSpec: JobSpec) = JobSpecDependencyActor.props(jobSpec, runService)
 
   val serviceActor = leadershipModule.startWhenLeader(
-    JobSpecServiceActor.props(jobSpecRepository, persistenceActor, scheduleActor),
+    JobSpecServiceActor.props(jobSpecRepository, persistenceActor, scheduleActor, dependencyActor),
     "JobSpecServiceActor"
   )
 

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
@@ -1,0 +1,48 @@
+package dcos.metronome.jobspec.impl
+
+import akka.actor.{Actor, ActorLogging, Props, Stash}
+import dcos.metronome.jobrun.JobRunService
+import dcos.metronome.model.{Event, JobSpec}
+
+/**
+  * Manages one JobSpec.
+  *
+  * If the JobSpec has dependencies, it subscribes to the events of its dependencies, ie parents.
+  *
+  * This actor is analog to [[JobSpecSchedulerActor]].
+  *
+  * TODO: find a better name
+  */
+class JobSpecDependencyActor(initSpec: JobSpec, runService: JobRunService) extends Actor with Stash with ActorLogging {
+
+  val dependencyIndex = initSpec.dependencies.toSet
+
+  override def preStart(): Unit = {
+    super.preStart()
+    context.system.eventStream.subscribe(self, classOf[Event.JobRunFinished])
+  }
+
+  override def postStop(): Unit = {
+    context.system.eventStream.unsubscribe(self)
+    super.postStop()
+  }
+
+  override def receive: Receive = {
+    case Event.JobRunFinished(jobRun, _, _) if dependencyIndex.contains(jobRun.jobSpec.id) =>
+      // TODO: account for all dependencies. Also make sure that the finished job run is from the same frame.
+      runService.startJobRun(initSpec)
+
+    case Event.JobRunFailed(jobRun, _, _) if dependencyIndex.contains(jobRun.jobSpec.id) =>
+      ???
+
+    case Event.JobRunStarted(jobRun, _, _) if dependencyIndex.contains(jobRun.jobSpec.id) =>
+      ???
+  }
+}
+
+object JobSpecDependencyActor {
+
+  def props(spec: JobSpec, runService: JobRunService): Props = {
+    Props(new JobSpecDependencyActor(spec, runService))
+  }
+}

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
@@ -67,7 +67,7 @@ class JobSpecDependencyActor(initSpec: JobSpec, runService: JobRunService) exten
 
     case Status.Failure(cause) =>
       // escalate this failure
-      throw new IllegalStateException("while loading tasks", cause)
+      throw new IllegalStateException(s"while starting job ${spec.id}", cause)
 
     case Event.JobRunFinished(jobRun, _, _) if jobRun.id.jobId == initSpec.id =>
       lastSuccessfulRun = jobRun.completedAt.getOrElse(Instant.MIN)

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
@@ -115,9 +115,9 @@ object JobSpecDependencyActor {
         s"Should trigger: lastRun=$lastSuccessfulRun index=$dependencyIndex lastDependencyRuns=$lastSuccessfulRunDependencies"
       )
       val allParentsSuccessful = lastSuccessfulRunDependencies.keySet == dependencyIndex
-      val lastSuccessfulRunAfterParents = lastSuccessfulRunDependencies.values.forall(_.isAfter(lastSuccessfulRun))
+      val lastSuccessfulRunOlderThanParents = lastSuccessfulRunDependencies.values.forall(_.isAfter(lastSuccessfulRun))
 
-      allParentsSuccessful && lastSuccessfulRunAfterParents
+      allParentsSuccessful && lastSuccessfulRunOlderThanParents
     }
 
     def updateJobSpec(newJobSpec: JobSpec): Unit = {

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
@@ -1,4 +1,5 @@
-package dcos.metronome.jobspec.impl
+package dcos.metronome
+package jobspec.impl
 
 import java.time.Instant
 

--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
@@ -150,6 +150,16 @@ class JobSpecServiceActor(
           scheduleActors -= jobSpec.id
       }
     }
+    dependencyActor(jobSpec).foreach { actor =>
+      if (jobSpec.dependencies.nonEmpty) {
+        actor ! JobSpecDependencyActor.UpdateJobSpec(jobSpec)
+      } else {
+        //the updated spec does not have any dependencies
+        context.unwatch(actor)
+        context.stop(actor)
+        dependencyActors -= jobSpec.id
+      }
+    }
     context.system.eventStream.publish(Event.JobSpecUpdated(jobSpec))
     delegate ! jobSpec
   }

--- a/jobs/src/main/scala/dcos/metronome/model/Event.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/Event.scala
@@ -29,7 +29,9 @@ object Event {
       timestamp: Instant = Clock.systemUTC().instant()
   ) extends JobSpecEvent
 
-  trait JobRunEvent extends Event
+  trait JobRunEvent extends Event {
+    val jobRun: JobRun
+  }
   case class JobRunStarted(
       jobRun: JobRun,
       eventType: String = "job_run_started",

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
@@ -1,0 +1,126 @@
+package dcos.metronome.jobspec.impl
+
+import java.time.{Clock, LocalDateTime, ZoneOffset}
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestActorRef, TestKit}
+import dcos.metronome.{Seq, SettableClock}
+import dcos.metronome.jobrun.JobRunService
+import dcos.metronome.model.{Event, JobId, JobRun, JobRunId, JobRunStatus, JobSpec}
+import dcos.metronome.utils.test.Mockito
+import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+
+class JobSpecDependencyActorTest
+    extends TestKit(ActorSystem("test"))
+    with FunSuiteLike
+    with BeforeAndAfterAll
+    with GivenWhenThen
+    with ScalaFutures
+    with Matchers
+    with Eventually
+    with ImplicitSender
+    with Mockito {
+
+  test("when job A and B finish job C is triggered") {
+    Given("Job C with dependencies on job A and B")
+    val f = new Fixture()
+
+    And("A dependency actor for C without a last run")
+    val actor = f.dependencyActor
+
+    And("Successful runs for A and B")
+    val finished = f.clock.instant().plusSeconds(10)
+    val jobARun = JobRun(
+      JobRunId(f.jobA.id, "finished"),
+      f.jobA,
+      JobRunStatus.Success,
+      f.clock.instant(),
+      Some(finished),
+      None,
+      Map.empty
+    )
+    val jobBRun = JobRun(
+      JobRunId(f.jobB.id, "finished"),
+      f.jobB,
+      JobRunStatus.Success,
+      f.clock.instant(),
+      Some(finished),
+      None,
+      Map.empty
+    )
+
+    When("Job A and B finish")
+    actor ! Event.JobRunFinished(jobARun)
+    actor ! Event.JobRunFinished(jobBRun)
+
+    Then("Job C is triggered")
+    verify(f.jobRunService, timeout(1000).times(1)).startJobRun(f.jobC)
+    system.stop(actor)
+  }
+
+  test("when job A finished twice and B once C is triggered after B") {
+    Given("Job C with dependencies on job A and B")
+    val f = new Fixture()
+
+    And("A dependency actor for C without a last run")
+    val actor = f.dependencyActor
+
+    And("A already finished once")
+    val firstTime = f.clock.instant().plusSeconds(10)
+    val jobARun1 = JobRun(
+      JobRunId(f.jobA.id, "finished"),
+      f.jobA,
+      JobRunStatus.Success,
+      f.clock.instant(),
+      Some(firstTime),
+      None,
+      Map.empty
+    )
+    actor ! Event.JobRunFinished(jobARun1)
+
+    When("Job A finishes the second time and B finish its first time")
+    val secondTime = f.clock.instant().plusSeconds(20)
+    val jobARun2 = JobRun(
+      JobRunId(f.jobA.id, "finished"),
+      f.jobA,
+      JobRunStatus.Success,
+      f.clock.instant(),
+      Some(secondTime),
+      None,
+      Map.empty
+    )
+    val jobBRun = JobRun(
+      JobRunId(f.jobB.id, "finished"),
+      f.jobB,
+      JobRunStatus.Success,
+      f.clock.instant(),
+      Some(secondTime),
+      None,
+      Map.empty
+    )
+    actor ! Event.JobRunFinished(jobARun2)
+    actor ! Event.JobRunFinished(jobBRun)
+
+    Then("Job C is triggered only once")
+    verify(f.jobRunService, timeout(1000).times(1)).startJobRun(f.jobC)
+    system.stop(actor)
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+  }
+
+  class Fixture {
+    // 01:59am CDT 2017-11-05 was end of daylight saving time
+    val clock = new SettableClock(
+      Clock.fixed(LocalDateTime.parse("2018-01-13T13:59").toInstant(ZoneOffset.UTC), ZoneOffset.UTC)
+    )
+
+    val jobA = JobSpec(JobId("a"))
+    val jobB = JobSpec(JobId("b"))
+    val jobC = JobSpec(JobId("c"), dependencies = Seq(jobA.id, jobB.id))
+    val jobRunService = mock[JobRunService]
+    def dependencyActor = TestActorRef[JobSpecDependencyActor](JobSpecDependencyActor.props(jobC, jobRunService))
+  }
+}

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
@@ -12,7 +12,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 
 class JobSpecDependencyActorTest
-    extends TestKit(ActorSystem("test"))
+    extends TestKit(ActorSystem("job-dependency-test"))
     with FunSuiteLike
     with BeforeAndAfterAll
     with GivenWhenThen

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecServiceActorTest.scala
@@ -313,6 +313,8 @@ class JobSpecServiceActorTest
     val dummyProp = Props(new TestActor(dummyQueue))
     val jobSpec = JobSpec(JobId("test"))
     val jobSpecService =
-      TestActorRef[JobSpecServiceActor](JobSpecServiceActor.props(repository, (_: JobId) => dummyProp, _ => dummyProp))
+      TestActorRef[JobSpecServiceActor](
+        JobSpecServiceActor.props(repository, (_: JobId) => dummyProp, _ => dummyProp, _ => dummyProp)
+      )
   }
 }


### PR DESCRIPTION
Summary:
This the business logic of MIP 0008 "Jobs with Dependencies". We had an actor analog
to the `JobSpecSchedulerActor`. This new actor subscribes to all job run events and updates
an internal state. Once all parents have a successful run that is new than the child run we
trigger new job execution.

JIRA issues: DCOS_OSS-5974