### PR TITLE
Job with dependency follow up.

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActor.scala
@@ -5,9 +5,8 @@ import java.time.Instant
 
 import akka.actor.{Actor, ActorLogging, Props, Stash, Status}
 import akka.pattern.pipe
-import com.typesafe.scalalogging.StrictLogging
 import dcos.metronome.jobrun.{JobRunService, StartedJobRun}
-import dcos.metronome.jobspec.impl.JobSpecDependencyActor.{DependenciesState, UpdateJobSpec}
+import dcos.metronome.jobspec.impl.JobSpecDependencyActor.UpdateJobSpec
 import dcos.metronome.model.{Event, JobId, JobRun, JobRunStatus, JobSpec}
 
 import scala.collection.mutable
@@ -25,14 +24,29 @@ import scala.concurrent.ExecutionContext
 class JobSpecDependencyActor(initSpec: JobSpec, runService: JobRunService) extends Actor with Stash with ActorLogging {
 
   private[impl] var spec = initSpec
+
+  // Time when this job spec finished successfully the last time.
   private[impl] var lastSuccessfulRun: Instant = Instant.MIN
-  val dependenciesState = DependenciesState(initSpec.dependencies.toSet)
+
+  // Time when this job spec was triggered the last time.
+  private[impl] var lastStartedAt: Option[Instant] = None
+
+  // An index of all parents
+  private[impl] var dependencyIndex: Set[JobId] = spec.dependencies.toSet
+
+  // State of latest parents' runs.
+  val lastParentRuns: mutable.Map[JobId, JobRun] = mutable.Map.empty
 
   implicit val ec: ExecutionContext = context.dispatcher
 
   override def preStart(): Unit = {
     super.preStart()
     context.system.eventStream.subscribe(self, classOf[Event.JobRunEvent])
+
+    // Get active run for this job.
+    // TODO: load history
+    runService.listRuns(jobRun => jobRun.id.jobId == spec.id).pipeTo(self)
+    log.info(s"Started for job ${spec.id}: id=${spec.id} dependencies=[${dependencyIndex.mkString(", ")}]")
   }
 
   override def postStop(): Unit = {
@@ -40,93 +54,102 @@ class JobSpecDependencyActor(initSpec: JobSpec, runService: JobRunService) exten
     super.postStop()
   }
 
-  override def receive: Receive = idling
+  override def receive: Receive = initializing
 
-  def idling: Receive = {
+  def initializing: Receive = {
+    case activeRuns: Iterable[StartedJobRun] =>
+      lastStartedAt = activeRuns.map(_.jobRun.createdAt).toVector.sorted.lastOption
+      context.become(initialized)
+      unstashAll()
+
+    case Status.Failure(cause) =>
+      // escalate this failure
+      throw new IllegalStateException(s"while starting job ${spec.id}", cause)
+
+    case other =>
+      log.debug(s"Stashing $other")
+      stash()
+  }
+
+  def initialized: Receive = {
     case ev: Event.JobRunEvent =>
-      dependenciesState.update(ev.jobRun)
-      if (dependenciesState.shouldTriggerJob(lastSuccessfulRun)) {
-        log.info(s"Start next run of job ${spec.id}, all parents finished successfully")
+      update(ev.jobRun)
+      if (shouldTriggerJob()) {
+        log.info(
+          s"Start next run of job ${spec.id}, all parents finished successfully lastParentRuns=${lastParentRuns.values}"
+        )
         runService.startJobRun(initSpec).pipeTo(self)
-        context.become(running)
+        context.become(starting)
       }
 
     case UpdateJobSpec(newJobSpec) =>
       log.debug(s"Update job spec. id=${newJobSpec.id}")
       require(newJobSpec.id == spec.id)
-      spec = newJobSpec
-      dependenciesState.updateJobSpec(newJobSpec)
+      updateJobSpec(newJobSpec)
   }
 
   /**
     * State when the job was triggered. All messages are stashed until the job either finishes or fails.
     * This means we cannot have concurrent job runs of this job.
     */
-  def running: Receive = {
-    case StartedJobRun => ()
+  def starting: Receive = {
+    case StartedJobRun(run, _) =>
+      require(run.id.jobId == spec.id)
+      lastStartedAt = Some(run.createdAt)
+      context.become(initialized)
+      unstashAll()
 
     case Status.Failure(cause) =>
       // escalate this failure
       throw new IllegalStateException(s"while starting job ${spec.id}", cause)
 
-    case Event.JobRunFinished(jobRun, _, _) if jobRun.id.jobId == initSpec.id =>
-      lastSuccessfulRun = jobRun.completedAt.getOrElse(Instant.MIN)
-      context.become(idling)
-      unstashAll()
-
-    case Event.JobRunFailed(jobRun, _, _) if jobRun.id.jobId == initSpec.id =>
-      lastSuccessfulRun = Instant.MIN
-      context.become(idling)
-      unstashAll()
-
     case other =>
       log.debug(s"Stashing $other")
       stash()
+  }
+
+  def update(jobRun: JobRun): Unit = {
+    log.debug(s"Updating state: jobRun=$jobRun")
+    if (dependencyIndex.contains(jobRun.id.jobId)) {
+      lastParentRuns.update(jobRun.id.jobId, jobRun)
+    } else if (jobRun.id.jobId == spec.id) {
+      if (jobRun.status == JobRunStatus.Success) {
+        lastSuccessfulRun = jobRun.completedAt.get
+      }
+      // TODO: handle error case
+    }
+  }
+
+  /**
+    * @return true if the last successful run of the child is older than all parent runs.
+    */
+  def shouldTriggerJob(): Boolean = {
+    log.debug(
+      s"Should trigger job: id${spec.id} lastRun=$lastSuccessfulRun index=$dependencyIndex lastDependencyRuns=$lastParentRuns"
+    )
+    val allParentsSuccessful = dependencyIndex.forall { p =>
+      lastParentRuns.get(p).exists(_.status == JobRunStatus.Success)
+    }
+    val lastSuccessfulRunOlderThanParents = lastParentRuns.valuesIterator.forall { lastRun =>
+      lastRun.completedAt.exists(_.isAfter(lastSuccessfulRun))
+    }
+    val didNotTriggerJobYet = !lastStartedAt.exists(_.isAfter(lastSuccessfulRun))
+
+    allParentsSuccessful && lastSuccessfulRunOlderThanParents && didNotTriggerJobYet
+  }
+
+  def updateJobSpec(newJobSpec: JobSpec): Unit = {
+    spec = newJobSpec
+    dependencyIndex = newJobSpec.dependencies.toSet
+
+    // Remove dependencies from last successful runs
+    lastParentRuns.keySet.diff(dependencyIndex).foreach(lastParentRuns.remove)
   }
 }
 
 object JobSpecDependencyActor {
 
   case class UpdateJobSpec(newSpec: JobSpec)
-
-  case class DependenciesState(dependencies: Set[JobId]) extends StrictLogging {
-
-    // An index of all parents
-    private[impl] var dependencyIndex: Set[JobId] = dependencies
-
-    // State of all successful parents runs.
-    val lastSuccessfulRunDependencies: mutable.Map[JobId, Instant] = mutable.Map.empty
-
-    def update(jobRun: JobRun): Unit = {
-      if (dependencyIndex.contains(jobRun.id.jobId)) {
-        if (jobRun.status == JobRunStatus.Success) {
-          lastSuccessfulRunDependencies.update(jobRun.id.jobId, jobRun.completedAt.get)
-        } else if (jobRun.status == JobRunStatus.Failed) {
-          lastSuccessfulRunDependencies.remove(jobRun.jobSpec.id)
-        }
-      }
-    }
-
-    /**
-      * @return true if the last successful run of the child is older than all parent runs.
-      */
-    def shouldTriggerJob(lastSuccessfulRun: Instant): Boolean = {
-      logger.debug(
-        s"Should trigger: lastRun=$lastSuccessfulRun index=$dependencyIndex lastDependencyRuns=$lastSuccessfulRunDependencies"
-      )
-      val allParentsSuccessful = lastSuccessfulRunDependencies.keySet == dependencyIndex
-      val lastSuccessfulRunOlderThanParents = lastSuccessfulRunDependencies.values.forall(_.isAfter(lastSuccessfulRun))
-
-      allParentsSuccessful && lastSuccessfulRunOlderThanParents
-    }
-
-    def updateJobSpec(newJobSpec: JobSpec): Unit = {
-      dependencyIndex = newJobSpec.dependencies.toSet
-
-      // Remove dependencies from last successful runs
-      lastSuccessfulRunDependencies.keySet.diff(dependencyIndex).foreach(lastSuccessfulRunDependencies.remove)
-    }
-  }
 
   def props(spec: JobSpec, runService: JobRunService): Props = {
     Props(new JobSpecDependencyActor(spec, runService))

--- a/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
+++ b/jobs/src/test/scala/dcos/metronome/jobspec/impl/JobSpecDependencyActorTest.scala
@@ -5,11 +5,13 @@ import java.time.{Clock, LocalDateTime, ZoneOffset}
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit}
 import dcos.metronome.{Seq, SettableClock}
-import dcos.metronome.jobrun.JobRunService
+import dcos.metronome.jobrun.{JobRunService, StartedJobRun}
 import dcos.metronome.model.{Event, JobId, JobRun, JobRunId, JobRunStatus, JobSpec}
 import dcos.metronome.utils.test.Mockito
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike, GivenWhenThen, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
+
+import scala.concurrent.Future
 
 class JobSpecDependencyActorTest
     extends TestKit(ActorSystem("job-dependency-test"))
@@ -121,6 +123,9 @@ class JobSpecDependencyActorTest
     val jobB = JobSpec(JobId("b"))
     val jobC = JobSpec(JobId("c"), dependencies = Seq(jobA.id, jobB.id))
     val jobRunService = mock[JobRunService]
+
+    jobRunService.listRuns(any) returns Future.successful(Iterable.empty[StartedJobRun])
+
     def dependencyActor = TestActorRef[JobSpecDependencyActor](JobSpecDependencyActor.props(jobC, jobRunService))
   }
 }


### PR DESCRIPTION
Summary:
This change allows parallel execution of dependent jobs but does not
trigger a job twice if the parents did not run again.

Some small failure recovery is also introduced that loads the last
active job run of a dependent job.