### PR TITLE
Fix jobSpec dependencies format for GET

### DIFF
--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -355,7 +355,18 @@ package object models {
 
   implicit lazy val JobResultWrites: Writes[JobResult] = Json.writes[JobResult]
 
-  implicit lazy val JobInfoWrites: Writes[JobInfo] = Json.writes[JobInfo]
+  implicit lazy val JobInfoWrites: Writes[JobInfo] = { jobInfo: JobInfo =>
+    Json.obj(
+      "id" -> jobInfo.id,
+      "description" -> jobInfo.description,
+      "dependencies" -> DependencyFormat.writes(jobInfo.dependencies),
+      "labels" -> jobInfo.labels,
+      "run" -> jobInfo.run,
+      "schedules" -> jobInfo.schedules,
+      "activeRuns" -> jobInfo.activeRuns,
+      "history" -> jobInfo.history,
+      "historySummary" -> jobInfo.historySummary)
+  }
 
   implicit lazy val JsErrorWrites: Writes[JsError] = new Writes[JsError] {
     override def writes(error: JsError): JsValue =

--- a/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
+++ b/api/src/main/scala/dcos/metronome/api/v1/models/package.scala
@@ -356,7 +356,7 @@ package object models {
   implicit lazy val JobResultWrites: Writes[JobResult] = Json.writes[JobResult]
 
   implicit lazy val JobInfoWrites: Writes[JobInfo] = { jobInfo: JobInfo =>
-    Json.obj(
+    val fields = Json.obj(
       "id" -> jobInfo.id,
       "description" -> jobInfo.description,
       "dependencies" -> DependencyFormat.writes(jobInfo.dependencies),
@@ -365,7 +365,10 @@ package object models {
       "schedules" -> jobInfo.schedules,
       "activeRuns" -> jobInfo.activeRuns,
       "history" -> jobInfo.history,
-      "historySummary" -> jobInfo.historySummary)
+      "historySummary" -> jobInfo.historySummary
+    ).fields.filterNot(_._2 == JsNull)
+
+    JsObject(fields)
   }
 
   implicit lazy val JsErrorWrites: Writes[JsError] = new Writes[JsError] {

--- a/api/src/test/scala/dcos/metronome/api/v1/models/JsonSerializationTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/models/JsonSerializationTest.scala
@@ -2,6 +2,7 @@ package dcos.metronome
 package api.v1.models
 
 import com.mesosphere.utils.UnitTest
+import dcos.metronome.jobinfo.JobInfo
 import dcos.metronome.model.{JobId, JobSpec, Network}
 import play.api.libs.json._
 
@@ -17,10 +18,23 @@ class JsonSerializationTest extends UnitTest {
       Json.toJson(network) shouldBe Json.obj("mode" -> "host")
     }
 
-    "it parses job dependencies properly back and forth" in {
-      val jobSpec = JobSpec(id = JobId("a"), dependencies = Seq(JobId("b")))
-      val reparsed = Json.toJson(jobSpec).as[JobSpec]
-      reparsed.dependencies shouldBe Seq(JobId("b"))
+    "jobSpec formatting" should {
+      val jobSpec = JobSpec(id = JobId("b"), dependencies = Seq(JobId("a")))
+
+      "parse job dependencies properly back and forth" in {
+        val jobJson = Json.toJson(jobSpec)
+        (jobJson \ "dependencies").get shouldBe Json.arr(Json.obj("id" -> "a"))
+        val reparsed = jobJson.as[JobSpec]
+        reparsed.dependencies shouldBe Seq(JobId("a"))
+      }
+
+      "parse a serialized JobInfo" in {
+        val jobInfo = JobInfo(jobSpec, Nil, None, None, None)
+        val jobInfoJson = Json.toJson(jobInfo)
+        val reparsed = jobInfoJson.as[JobSpec]
+        reparsed.dependencies shouldBe Seq(JobId("a"))
+      }
+
     }
   }
 }

--- a/api/src/test/scala/dcos/metronome/api/v1/models/JsonSerializationTest.scala
+++ b/api/src/test/scala/dcos/metronome/api/v1/models/JsonSerializationTest.scala
@@ -1,7 +1,8 @@
-package dcos.metronome.api.v1.models
+package dcos.metronome
+package api.v1.models
 
 import com.mesosphere.utils.UnitTest
-import dcos.metronome.model.Network
+import dcos.metronome.model.{JobId, JobSpec, Network}
 import play.api.libs.json._
 
 class JsonSerializationTest extends UnitTest {
@@ -14,6 +15,12 @@ class JsonSerializationTest extends UnitTest {
     "drops empty name and labels from the serialized json" in {
       val network = Network(name = None, mode = Network.NetworkMode.Host, labels = Map.empty)
       Json.toJson(network) shouldBe Json.obj("mode" -> "host")
+    }
+
+    "it parses job dependencies properly back and forth" in {
+      val jobSpec = JobSpec(id = JobId("a"), dependencies = Seq(JobId("b")))
+      val reparsed = Json.toJson(jobSpec).as[JobSpec]
+      reparsed.dependencies shouldBe Seq(JobId("b"))
     }
   }
 }

--- a/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobinfo/JobInfo.scala
@@ -17,6 +17,7 @@ case class JobInfo(
     activeRuns: Option[Iterable[StartedJobRun]],
     history: Option[JobHistory],
     historySummary: Option[JobHistorySummary]
+    // adding a field here? Make sure you update JobInfoWrites!
 )
 
 object JobInfo {


### PR DESCRIPTION
The format for dependencies differed between jobSpec POST and GET. POST expects an array of objects, but GET returns an array of strings.

This resolves the disagreement and adds a unit test to assert it.

JIRA Issues: https://jira.d2iq.com/browse/DCOS_OSS-5988
