### PR TITLE
D2IQ-71940 don't let cyclic deps crash the validation

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
+++ b/jobs/src/main/scala/dcos/metronome/model/JobSpec.scala
@@ -92,13 +92,10 @@ object JobSpec {
     * @return true if there is a path, false if not.
     */
   def findPath(specs: Map[JobId, JobSpec], start: JobId, end: JobSpec, visited: Seq[JobId] = Seq()): Boolean = {
-    if (start == end.id) {
-      true
-    } else {
-      specs(start).dependencies
-        .filter(d => !(visited.contains(d)))
-        .exists(findPath(specs, _, end, visited ++ Seq(start)))
-    }
+    if (start == end.id) return true
+    specs(start).dependencies
+      .filter(d => !(visited.contains(d)))
+      .exists(findPath(specs, _, end, visited ++ Seq(start)))
   }
 
   /**


### PR DESCRIPTION
we enhance the DFS here to only inspect nodes that have not been
inspected before.
the actor is grateful for it does not need to check the same dependencies over and over again for all eternity if someone tries to introduce a cyclic dependency.

## JIRAs

https://jira.d2iq.com/browse/D2IQ-71940