### PR TITLE
fix: remove job from inFlightChanges when action fails

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
@@ -101,7 +101,11 @@ class JobSpecServiceActor(
     if (inFlightChanges.contains(jobSpec.id)) sender() ! Status.Failure(JobSpecChangeInFlight(jobSpec.id))
     else {
       inFlightChanges += jobSpec.id
-      change
+      try {
+        change
+      } catch {
+        case _ => inFlightChanges -= jobSpec.id
+      }
     }
   }
 


### PR DESCRIPTION
we're currently facing the situation that the JobSpecServiceActor does
refuse to alter a JobSpec with dependants after we tried to delete it
once.
On deletion it's expected to get an error that states that we need to
remove the dependants first.
When trying to edit or delete it again afterwards, we can see in the
logs that we still have inFlightChanges.
so let's tell the actor to remove the job from that list in case the
action failed.

JIRA issues:
* https://jira.d2iq.com/browse/D2IQ-72421