### PR TITLE
D2IQ-72421 clean up inFlightChanges on DependencyConflict

### DIFF
--- a/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
+++ b/jobs/src/main/scala/dcos/metronome/jobspec/impl/JobSpecServiceActor.scala
@@ -114,7 +114,11 @@ class JobSpecServiceActor(
       JobSpec.validateSafeDelete(jobSpec.id, allJobs.values.toVector)
       change
     } catch {
-      case ex: JobSpec.DependencyConflict => sender() ! Status.Failure(ex)
+      case ex: JobSpec.DependencyConflict => {
+        inFlightChanges -= jobSpec.id
+        sender() ! Status.Failure(ex)
+      }
+      case e: Exception => throw e
     }
   }
 


### PR DESCRIPTION
we're still facing the situation that the JobSpecServiceActor does
refuse to alter a JobSpec with dependants after we tried to delete it
once.
On deletion it's expected to get an error that states that we need to
remove the dependants first.
When trying to edit or delete it again afterwards, we can see in the
logs that we still have inFlightChanges.
so let's tell the actor to remove the job from that list in case the
action failed.

